### PR TITLE
feat: add zorro chain to v3 deployments

### DIFF
--- a/deployments/v3/addresses.json
+++ b/deployments/v3/addresses.json
@@ -913,5 +913,17 @@
     "relayApprovalProxy": "0xccc88a9d1b4ed6b0eaba998850414b24f1c315be",
     "create2Factory": "0x4e59b44847b379578588920ca78fbf26c0b4956c",
     "permit2": "0x000000000022d473030f116ddee9f6b43ac78ba3"
+  },
+  {
+    "name": "zorro",
+    "chainId": 4663,
+    "compilerVersion": "0.8.28",
+    "evmVersion": "cancun",
+    "explorerUrl": "https://8crv4vmq6tiu1yqr.blockscout.com",
+    "verificationFlags": "--verifier blockscout --verifier-url https://8crv4vmq6tiu1yqr.blockscout.com/api/",
+    "relayRouter": "0xb92fe925dc43a0ecde6c8b1a2709c170ec4fff4f",
+    "relayApprovalProxy": "0xccc88a9d1b4ed6b0eaba998850414b24f1c315be",
+    "create2Factory": "0x4e59b44847b379578588920ca78fbf26c0b4956c",
+    "permit2": "0x000000000022d473030f116ddee9f6b43ac78ba3"
   }
 ]


### PR DESCRIPTION
Linear: [DEC-887](https://linear.app/relayprotocol/issue/DEC-887/deploy-zorro-contracts-with-opsec-requirements)

## Summary
- Add zorro (chainId 4663) to `deployments/v3/addresses.json`
- `RelayRouterV3` and `RelayApprovalProxyV3` deployed at canonical addresses via the default CREATE2 factory + canonical Permit2
- Explorer uses Blockscout (basic-auth-gated while the chain is private; verifier URL is included without credentials)

## Addresses
- `relayRouter`: `0xb92fe925dc43a0ecde6c8b1a2709c170ec4fff4f`
- `relayApprovalProxy`: `0xccc88a9d1b4ed6b0eaba998850414b24f1c315be`
- `create2Factory`: `0x4e59b44847b379578588920ca78fbf26c0b4956c`
- `permit2`: `0x000000000022d473030f116ddee9f6b43ac78ba3`