### PR TITLE
fix: require explicit multicall signature for ERC3009

### DIFF
--- a/src/v3/RelayApprovalProxyV3.sol
+++ b/src/v3/RelayApprovalProxyV3.sol
@@ -292,13 +292,10 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
             revert RefundToCannotBeZeroAddress();
         }
 
-        bytes32[] memory authorizationDigests = new bytes32[](
-            permits.length
-        );
         for (uint256 i = 0; i < permits.length; i++) {
-            address signer = permits[i].from;
-            authorizationDigests[i] = _getMulticallAuthorizationDigest(
-                signer,
+            Permit3009 memory permit = permits[i];
+            bytes32 authorizationDigest = _getMulticallAuthorizationDigest(
+                permit.from,
                 refundTo,
                 nftRecipient,
                 metadata,
@@ -307,17 +304,13 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
 
             // Verify each signature against the owner of the corresponding permit.
             if (
-                !signer.isValidSignatureNowCalldata(
-                    authorizationDigests[i],
+                !permit.from.isValidSignatureNowCalldata(
+                    authorizationDigest,
                     multicallSignatures[i]
                 )
             ) {
                 revert InvalidMulticallSignature();
             }
-        }
-
-        for (uint256 i = 0; i < permits.length; i++) {
-            Permit3009 memory permit = permits[i];
 
             // The authorization digest is also the ERC3009 nonce, so this
             // authorization cannot be used with different multicall details.
@@ -327,7 +320,7 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
                 permit.value,
                 permit.validAfter,
                 permit.validBefore,
-                authorizationDigests[i],
+                authorizationDigest,
                 permit.v,
                 permit.r,
                 permit.s

--- a/src/v3/RelayApprovalProxyV3.sol
+++ b/src/v3/RelayApprovalProxyV3.sol
@@ -10,6 +10,7 @@ import {
     ISignatureTransfer
 } from "permit2-relay/src/interfaces/ISignatureTransfer.sol";
 import {Ownable} from "solady/src/auth/Ownable.sol";
+import {EIP712} from "solady/src/utils/EIP712.sol";
 import {SignatureCheckerLib} from "solady/src/utils/SignatureCheckerLib.sol";
 import {TrustlessPermit} from "trustlessPermit/TrustlessPermit.sol";
 
@@ -18,7 +19,7 @@ import {IERC3009} from "../common/IERC3009.sol";
 import {Call3Value, Result} from "../common/Multicall3.sol";
 import {Permit2612, Permit3009} from "../common/Permits.sol";
 
-contract RelayApprovalProxyV3 is Ownable {
+contract RelayApprovalProxyV3 is Ownable, EIP712 {
     using SafeERC20 for IERC20;
     using SignatureCheckerLib for address;
     using TrustlessPermit for address;
@@ -26,8 +27,14 @@ contract RelayApprovalProxyV3 is Ownable {
     /// @notice Revert if the array lengths do not match
     error ArrayLengthsMismatch();
 
+    /// @notice Revert if the multicall authorization signature is invalid
+    error InvalidMulticallSignature();
+
     /// @notice Revert if the native transfer fails
     error NativeTransferFailed();
+
+    /// @notice Revert if a permit does not belong to the authorizing user
+    error PermitOwnerMismatch();
 
     /// @notice Revert if the refundTo address is zero address
     error RefundToCannotBeZeroAddress();
@@ -50,6 +57,10 @@ contract RelayApprovalProxyV3 is Ownable {
     bytes32 public constant _CALL3VALUE_TYPEHASH =
         keccak256(
             "Call3Value(address target,bool allowFailure,uint256 value,bytes callData)"
+        );
+    bytes32 public constant _MULTICALL_AUTHORIZATION_TYPEHASH =
+        keccak256(
+            "MulticallAuthorization(address from,address relayer,address refundTo,address nftRecipient,bytes metadata,Call3Value[] calls)Call3Value(address target,bool allowFailure,uint256 value,bytes callData)"
         );
     string public constant _RELAYER_WITNESS_TYPE_STRING =
         "RelayerWitness witness)Call3Value(address target,bool allowFailure,uint256 value,bytes callData)RelayerWitness(address relayer,address refundTo,address nftRecipient,bytes metadata,Call3Value[] call3Values)TokenPermissions(address token,uint256 amount)";
@@ -243,23 +254,28 @@ contract RelayApprovalProxyV3 is Ownable {
         );
     }
 
-    /// @notice Use ERC3009 permit to transfer tokens to RelayRouter and execute multicall in a single tx
-    /// @dev    Approved spender must be address(this) to transfer user's tokens to the RelayRouter. If leftover native tokens
-    ///         is expected as part of the multicall, be sure to set refundTo to the expected recipient. If the multicall
-    ///         includes ERC721/ERC1155 mints or transfers, be sure to set nftRecipient to the expected recipient.
+    /// @notice Use ERC3009 authorizations to transfer tokens to RelayRouter and execute a signed multicall
+    /// @dev    The user must sign the MulticallAuthorization typed data in addition to each ERC3009 authorization.
+    ///         The typed-data digest is used as each ERC3009 nonce, cryptographically binding the token transfers to
+    ///         the displayed call targets, values, data, and other execution parameters.
+    /// @param user The user authorizing the multicall and all token transfers
     /// @param permits An array of permits
+    /// @param tokens An array of tokens corresponding to the permits
     /// @param calls The calls to perform
     /// @param refundTo The address to refund any leftover native tokens to
     /// @param nftRecipient The address to set as recipient of ERC721/ERC1155 mints
     /// @param metadata Additional data to associate the call to
+    /// @param multicallSignature The user's EIP712 signature over the MulticallAuthorization
     /// @return returnData The return data from the multicall
     function permit3009TransferAndMulticall(
+        address user,
         Permit3009[] calldata permits,
         address[] calldata tokens,
         Call3Value[] calldata calls,
         address refundTo,
         address nftRecipient,
-        bytes calldata metadata
+        bytes calldata metadata,
+        bytes calldata multicallSignature
     ) external payable returns (Result[] memory returnData) {
         // Revert if array lengths do not match
         if ((tokens.length != permits.length)) {
@@ -271,17 +287,40 @@ contract RelayApprovalProxyV3 is Ownable {
             revert RefundToCannotBeZeroAddress();
         }
 
+        bytes32 authorizationDigest = _getMulticallAuthorizationDigest(
+            user,
+            refundTo,
+            nftRecipient,
+            metadata,
+            calls
+        );
+
+        // Verify the signature that presents all multicall details to the user.
+        if (
+            !user.isValidSignatureNowCalldata(
+                authorizationDigest,
+                multicallSignature
+            )
+        ) {
+            revert InvalidMulticallSignature();
+        }
+
         for (uint256 i = 0; i < permits.length; i++) {
             Permit3009 memory permit = permits[i];
 
-            // Use the permit
+            if (permit.from != user) {
+                revert PermitOwnerMismatch();
+            }
+
+            // The authorization digest is also the ERC3009 nonce, so this
+            // authorization cannot be used with different multicall details.
             IERC3009(tokens[i]).receiveWithAuthorization(
                 permit.from,
                 address(this),
                 permit.value,
                 permit.validAfter,
                 permit.validBefore,
-                _getRelayerWitnessHash(refundTo, nftRecipient, metadata, calls),
+                authorizationDigest,
                 permit.v,
                 permit.r,
                 permit.s
@@ -329,6 +368,35 @@ contract RelayApprovalProxyV3 is Ownable {
         }
 
         return keccak256(abi.encodePacked(callHashes));
+    }
+
+    /// @notice Internal function to get the EIP712 digest of a multicall authorization
+    /// @param user The user authorizing the multicall
+    /// @param refundTo The address to refund any leftover native tokens to
+    /// @param nftRecipient The nftRecipient address
+    /// @param metadata Additional data to associate the call to
+    /// @param calls The calls to be executed
+    function _getMulticallAuthorizationDigest(
+        address user,
+        address refundTo,
+        address nftRecipient,
+        bytes memory metadata,
+        Call3Value[] memory calls
+    ) internal view returns (bytes32) {
+        return
+            _hashTypedData(
+                keccak256(
+                    abi.encode(
+                        _MULTICALL_AUTHORIZATION_TYPEHASH,
+                        user,
+                        msg.sender,
+                        refundTo,
+                        nftRecipient,
+                        keccak256(metadata),
+                        _getCallsHash(calls)
+                    )
+                )
+            );
     }
 
     /// @notice Internal function to get the hash of a relayer witness
@@ -412,6 +480,16 @@ contract RelayApprovalProxyV3 is Ownable {
             _RELAYER_WITNESS_TYPE_STRING,
             permitSignature
         );
+    }
+
+    function _domainNameAndVersion()
+        internal
+        pure
+        override
+        returns (string memory name, string memory version)
+    {
+        name = "RelayApprovalProxyV3";
+        version = "1";
     }
 
     function _send(address to, uint256 value) internal {

--- a/src/v3/RelayApprovalProxyV3.sol
+++ b/src/v3/RelayApprovalProxyV3.sol
@@ -36,6 +36,9 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
     /// @notice Revert if a permit does not belong to the authorizing user
     error PermitOwnerMismatch();
 
+    /// @notice Revert if no ERC3009 permits are provided
+    error PermitsCannotBeEmpty();
+
     /// @notice Revert if the refundTo address is zero address
     error RefundToCannotBeZeroAddress();
 
@@ -258,7 +261,6 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
     /// @dev    The user must sign the MulticallAuthorization typed data in addition to each ERC3009 authorization.
     ///         The typed-data digest is used as each ERC3009 nonce, cryptographically binding the token transfers to
     ///         the displayed call targets, values, data, and other execution parameters.
-    /// @param user The user authorizing the multicall and all token transfers
     /// @param permits An array of permits
     /// @param tokens An array of tokens corresponding to the permits
     /// @param calls The calls to perform
@@ -268,7 +270,6 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
     /// @param multicallSignature The user's EIP712 signature over the MulticallAuthorization
     /// @return returnData The return data from the multicall
     function permit3009TransferAndMulticall(
-        address user,
         Permit3009[] calldata permits,
         address[] calldata tokens,
         Call3Value[] calldata calls,
@@ -282,13 +283,18 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
             revert ArrayLengthsMismatch();
         }
 
+        if (permits.length == 0) {
+            revert PermitsCannotBeEmpty();
+        }
+
         // Revert if refundTo is zero address
         if (refundTo == address(0)) {
             revert RefundToCannotBeZeroAddress();
         }
 
+        address signer = permits[0].from;
         bytes32 authorizationDigest = _getMulticallAuthorizationDigest(
-            user,
+            signer,
             refundTo,
             nftRecipient,
             metadata,
@@ -297,7 +303,7 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
 
         // Verify the signature that presents all multicall details to the user.
         if (
-            !user.isValidSignatureNowCalldata(
+            !signer.isValidSignatureNowCalldata(
                 authorizationDigest,
                 multicallSignature
             )
@@ -308,7 +314,7 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
         for (uint256 i = 0; i < permits.length; i++) {
             Permit3009 memory permit = permits[i];
 
-            if (permit.from != user) {
+            if (permit.from != signer) {
                 revert PermitOwnerMismatch();
             }
 

--- a/src/v3/RelayApprovalProxyV3.sol
+++ b/src/v3/RelayApprovalProxyV3.sol
@@ -58,9 +58,13 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
         keccak256(
             "Call3Value(address target,bool allowFailure,uint256 value,bytes callData)"
         );
+    bytes32 public constant _FUNDING_AUTHORIZATION_TYPEHASH =
+        keccak256(
+            "FundingAuthorization(address token,address from,uint256 value,uint256 validAfter,uint256 validBefore)"
+        );
     bytes32 public constant _MULTICALL_AUTHORIZATION_TYPEHASH =
         keccak256(
-            "MulticallAuthorization(address from,address relayer,address refundTo,address nftRecipient,bytes metadata,Call3Value[] calls)Call3Value(address target,bool allowFailure,uint256 value,bytes callData)"
+            "MulticallAuthorization(address from,address relayer,address refundTo,address nftRecipient,bytes metadata,uint256 fundingIndex,Call3Value[] calls,FundingAuthorization[] funding)Call3Value(address target,bool allowFailure,uint256 value,bytes callData)FundingAuthorization(address token,address from,uint256 value,uint256 validAfter,uint256 validBefore)"
         );
     string public constant _RELAYER_WITNESS_TYPE_STRING =
         "RelayerWitness witness)Call3Value(address target,bool allowFailure,uint256 value,bytes callData)RelayerWitness(address relayer,address refundTo,address nftRecipient,bytes metadata,Call3Value[] call3Values)TokenPermissions(address token,uint256 amount)";
@@ -267,8 +271,8 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
 
     /// @notice Use ERC3009 authorizations to transfer tokens to RelayRouter and execute a signed multicall
     /// @dev    The user must sign the MulticallAuthorization typed data in addition to each ERC3009 authorization.
-    ///         The typed-data digest is used as each ERC3009 nonce, cryptographically binding the token transfers to
-    ///         the displayed call targets, values, data, and other execution parameters.
+    ///         The typed-data digest is used as each ERC3009 nonce, cryptographically binding the complete ordered
+    ///         funding batch to the displayed call targets, values, data, and other execution parameters.
     /// @param permits An array of permits
     /// @param tokens An array of tokens corresponding to the permits
     /// @param calls The calls to perform
@@ -303,6 +307,7 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
             revert RefundToCannotBeZeroAddress();
         }
 
+        bytes32 fundingHash = _getFundingHash(permits, tokens);
         for (uint256 i = 0; i < permits.length; i++) {
             _handlePermit3009(
                 permits[i],
@@ -311,6 +316,8 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
                 refundTo,
                 nftRecipient,
                 metadata,
+                fundingHash,
+                i,
                 multicallSignatures[i]
             );
         }
@@ -334,6 +341,8 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
         address refundTo,
         address nftRecipient,
         bytes calldata metadata,
+        bytes32 fundingHash,
+        uint256 fundingIndex,
         bytes calldata multicallSignature
     ) internal {
         bytes32 authorizationDigest = _getMulticallAuthorizationDigest(
@@ -341,7 +350,9 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
             refundTo,
             nftRecipient,
             metadata,
-            calls
+            calls,
+            fundingHash,
+            fundingIndex
         );
 
         // Verify the signature against the owner of the corresponding permit.
@@ -402,18 +413,44 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
         return keccak256(abi.encodePacked(callHashes));
     }
 
+    /// @notice Internal function to hash the complete ordered ERC3009 funding batch
+    function _getFundingHash(
+        Permit3009[] calldata permits,
+        address[] calldata tokens
+    ) internal pure returns (bytes32) {
+        bytes32[] memory fundingHashes = new bytes32[](permits.length);
+        for (uint256 i = 0; i < permits.length; i++) {
+            fundingHashes[i] = keccak256(
+                abi.encode(
+                    _FUNDING_AUTHORIZATION_TYPEHASH,
+                    tokens[i],
+                    permits[i].from,
+                    permits[i].value,
+                    permits[i].validAfter,
+                    permits[i].validBefore
+                )
+            );
+        }
+
+        return keccak256(abi.encodePacked(fundingHashes));
+    }
+
     /// @notice Internal function to get the EIP712 digest of a multicall authorization
     /// @param user The user authorizing the multicall
     /// @param refundTo The address to refund any leftover native tokens to
     /// @param nftRecipient The nftRecipient address
     /// @param metadata Additional data to associate the call to
     /// @param calls The calls to be executed
+    /// @param fundingHash The hash of the complete ordered funding batch
+    /// @param fundingIndex The index of the permit within the funding batch
     function _getMulticallAuthorizationDigest(
         address user,
         address refundTo,
         address nftRecipient,
         bytes memory metadata,
-        Call3Value[] memory calls
+        Call3Value[] memory calls,
+        bytes32 fundingHash,
+        uint256 fundingIndex
     ) internal view returns (bytes32) {
         return
             _hashTypedData(
@@ -425,7 +462,9 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
                         refundTo,
                         nftRecipient,
                         keccak256(metadata),
-                        _getCallsHash(calls)
+                        fundingIndex,
+                        _getCallsHash(calls),
+                        fundingHash
                     )
                 )
             );

--- a/src/v3/RelayApprovalProxyV3.sol
+++ b/src/v3/RelayApprovalProxyV3.sol
@@ -33,9 +33,6 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
     /// @notice Revert if the native transfer fails
     error NativeTransferFailed();
 
-    /// @notice Revert if a permit does not belong to the authorizing user
-    error PermitOwnerMismatch();
-
     /// @notice Revert if no ERC3009 permits are provided
     error PermitsCannotBeEmpty();
 
@@ -267,7 +264,7 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
     /// @param refundTo The address to refund any leftover native tokens to
     /// @param nftRecipient The address to set as recipient of ERC721/ERC1155 mints
     /// @param metadata Additional data to associate the call to
-    /// @param multicallSignature The user's EIP712 signature over the MulticallAuthorization
+    /// @param multicallSignatures The EIP712 signatures over the MulticallAuthorization, corresponding to each permit
     /// @return returnData The return data from the multicall
     function permit3009TransferAndMulticall(
         Permit3009[] calldata permits,
@@ -276,10 +273,13 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
         address refundTo,
         address nftRecipient,
         bytes calldata metadata,
-        bytes calldata multicallSignature
+        bytes[] calldata multicallSignatures
     ) external payable returns (Result[] memory returnData) {
         // Revert if array lengths do not match
-        if ((tokens.length != permits.length)) {
+        if (
+            tokens.length != permits.length ||
+            multicallSignatures.length != permits.length
+        ) {
             revert ArrayLengthsMismatch();
         }
 
@@ -292,31 +292,32 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
             revert RefundToCannotBeZeroAddress();
         }
 
-        address signer = permits[0].from;
-        bytes32 authorizationDigest = _getMulticallAuthorizationDigest(
-            signer,
-            refundTo,
-            nftRecipient,
-            metadata,
-            calls
+        bytes32[] memory authorizationDigests = new bytes32[](
+            permits.length
         );
+        for (uint256 i = 0; i < permits.length; i++) {
+            address signer = permits[i].from;
+            authorizationDigests[i] = _getMulticallAuthorizationDigest(
+                signer,
+                refundTo,
+                nftRecipient,
+                metadata,
+                calls
+            );
 
-        // Verify the signature that presents all multicall details to the user.
-        if (
-            !signer.isValidSignatureNowCalldata(
-                authorizationDigest,
-                multicallSignature
-            )
-        ) {
-            revert InvalidMulticallSignature();
+            // Verify each signature against the owner of the corresponding permit.
+            if (
+                !signer.isValidSignatureNowCalldata(
+                    authorizationDigests[i],
+                    multicallSignatures[i]
+                )
+            ) {
+                revert InvalidMulticallSignature();
+            }
         }
 
         for (uint256 i = 0; i < permits.length; i++) {
             Permit3009 memory permit = permits[i];
-
-            if (permit.from != signer) {
-                revert PermitOwnerMismatch();
-            }
 
             // The authorization digest is also the ERC3009 nonce, so this
             // authorization cannot be used with different multicall details.
@@ -326,7 +327,7 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
                 permit.value,
                 permit.validAfter,
                 permit.validBefore,
-                authorizationDigest,
+                authorizationDigests[i],
                 permit.v,
                 permit.r,
                 permit.s

--- a/src/v3/RelayApprovalProxyV3.sol
+++ b/src/v3/RelayApprovalProxyV3.sol
@@ -208,6 +208,7 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
         );
 
         _cleanupErc20s(tokens, refundTo, metadata);
+        IRelayRouterV3(ROUTER).cleanupNative(0, refundTo, metadata);
     }
 
     /// @notice Use Permit2 to transfer tokens to RelayRouter and perform an arbitrary multicall.
@@ -261,6 +262,7 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
         if (permitSignature.length != 0) {
             _cleanupErc20s(tokens, refundTo, metadata);
         }
+        IRelayRouterV3(ROUTER).cleanupNative(0, refundTo, metadata);
     }
 
     /// @notice Use ERC3009 authorizations to transfer tokens to RelayRouter and execute a signed multicall
@@ -322,6 +324,7 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
         );
 
         _cleanupErc20s(tokens, refundTo, metadata);
+        IRelayRouterV3(ROUTER).cleanupNative(0, refundTo, metadata);
     }
 
     function _handlePermit3009(

--- a/src/v3/RelayApprovalProxyV3.sol
+++ b/src/v3/RelayApprovalProxyV3.sol
@@ -212,7 +212,6 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
         );
 
         _cleanupErc20s(tokens, refundTo, metadata);
-        IRelayRouterV3(ROUTER).cleanupNative(0, refundTo, metadata);
     }
 
     /// @notice Use Permit2 to transfer tokens to RelayRouter and perform an arbitrary multicall.
@@ -266,7 +265,6 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
         if (permitSignature.length != 0) {
             _cleanupErc20s(tokens, refundTo, metadata);
         }
-        IRelayRouterV3(ROUTER).cleanupNative(0, refundTo, metadata);
     }
 
     /// @notice Use ERC3009 authorizations to transfer tokens to RelayRouter and execute a signed multicall
@@ -331,7 +329,6 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
         );
 
         _cleanupErc20s(tokens, refundTo, metadata);
-        IRelayRouterV3(ROUTER).cleanupNative(0, refundTo, metadata);
     }
 
     function _handlePermit3009(

--- a/src/v3/RelayApprovalProxyV3.sol
+++ b/src/v3/RelayApprovalProxyV3.sol
@@ -161,8 +161,10 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
             revert RefundToCannotBeZeroAddress();
         }
 
+        address[] memory tokens = new address[](permits.length);
         for (uint256 i = 0; i < permits.length; i++) {
             Permit2612 memory permit = permits[i];
+            tokens[i] = permit.token;
 
             // Revert if the permit owner is not the msg.sender
             if (permit.owner != msg.sender) {
@@ -204,6 +206,8 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
             nftRecipient,
             metadata
         );
+
+        _cleanupErc20s(tokens, refundTo, metadata);
     }
 
     /// @notice Use Permit2 to transfer tokens to RelayRouter and perform an arbitrary multicall.
@@ -233,8 +237,9 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
         }
 
         // If a permit signature is provided, use it to transfer tokens from user to router
+        address[] memory tokens;
         if (permitSignature.length != 0) {
-            _handleBatchPermit(
+            tokens = _handleBatchPermit(
                 user,
                 refundTo,
                 nftRecipient,
@@ -252,6 +257,10 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
             nftRecipient,
             metadata
         );
+
+        if (permitSignature.length != 0) {
+            _cleanupErc20s(tokens, refundTo, metadata);
+        }
     }
 
     /// @notice Use ERC3009 authorizations to transfer tokens to RelayRouter and execute a signed multicall
@@ -293,48 +302,14 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
         }
 
         for (uint256 i = 0; i < permits.length; i++) {
-            Permit3009 memory permit = permits[i];
-            bytes32 authorizationDigest = _getMulticallAuthorizationDigest(
-                permit.from,
+            _handlePermit3009(
+                permits[i],
+                tokens[i],
+                calls,
                 refundTo,
                 nftRecipient,
                 metadata,
-                calls
-            );
-
-            // Verify each signature against the owner of the corresponding permit.
-            if (
-                !permit.from.isValidSignatureNowCalldata(
-                    authorizationDigest,
-                    multicallSignatures[i]
-                )
-            ) {
-                revert InvalidMulticallSignature();
-            }
-
-            // The authorization digest is also the ERC3009 nonce, so this
-            // authorization cannot be used with different multicall details.
-            IERC3009(tokens[i]).receiveWithAuthorization(
-                permit.from,
-                address(this),
-                permit.value,
-                permit.validAfter,
-                permit.validBefore,
-                authorizationDigest,
-                permit.v,
-                permit.r,
-                permit.s
-            );
-
-            // Transfer the tokens to the router
-            IERC20(tokens[i]).safeTransfer(ROUTER, permit.value);
-
-            emit FundsMovement(
-                permit.from,
-                ROUTER,
-                tokens[i],
-                permit.value,
-                metadata
+                multicallSignatures[i]
             );
         }
 
@@ -343,6 +318,60 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
             calls,
             refundTo,
             nftRecipient,
+            metadata
+        );
+
+        _cleanupErc20s(tokens, refundTo, metadata);
+    }
+
+    function _handlePermit3009(
+        Permit3009 memory permit,
+        address token,
+        Call3Value[] calldata calls,
+        address refundTo,
+        address nftRecipient,
+        bytes calldata metadata,
+        bytes calldata multicallSignature
+    ) internal {
+        bytes32 authorizationDigest = _getMulticallAuthorizationDigest(
+            permit.from,
+            refundTo,
+            nftRecipient,
+            metadata,
+            calls
+        );
+
+        // Verify the signature against the owner of the corresponding permit.
+        if (
+            !permit.from.isValidSignatureNowCalldata(
+                authorizationDigest,
+                multicallSignature
+            )
+        ) {
+            revert InvalidMulticallSignature();
+        }
+
+        // The authorization digest is also the ERC3009 nonce, so this
+        // authorization cannot be used with different multicall details.
+        IERC3009(token).receiveWithAuthorization(
+            permit.from,
+            address(this),
+            permit.value,
+            permit.validAfter,
+            permit.validBefore,
+            authorizationDigest,
+            permit.v,
+            permit.r,
+            permit.s
+        );
+
+        IERC20(token).safeTransfer(ROUTER, permit.value);
+
+        emit FundsMovement(
+            permit.from,
+            ROUTER,
+            token,
+            permit.value,
             metadata
         );
     }
@@ -439,7 +468,7 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
         ISignatureTransfer.PermitBatchTransferFrom memory permit,
         Call3Value[] calldata calls,
         bytes memory permitSignature
-    ) internal {
+    ) internal returns (address[] memory tokens) {
         bytes32 witness = _getRelayerWitnessHash(
             refundTo,
             nftRecipient,
@@ -452,8 +481,10 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
             memory signatureTransferDetails = new ISignatureTransfer.SignatureTransferDetails[](
                 permit.permitted.length
             );
+        tokens = new address[](permit.permitted.length);
         for (uint256 i = 0; i < permit.permitted.length; i++) {
             uint256 amount = permit.permitted[i].amount;
+            tokens[i] = permit.permitted[i].token;
 
             signatureTransferDetails[i] = ISignatureTransfer
                 .SignatureTransferDetails({
@@ -479,6 +510,25 @@ contract RelayApprovalProxyV3 is Ownable, EIP712 {
             witness,
             _RELAYER_WITNESS_TYPE_STRING,
             permitSignature
+        );
+    }
+
+    function _cleanupErc20s(
+        address[] memory tokens,
+        address refundTo,
+        bytes memory metadata
+    ) internal {
+        address[] memory recipients = new address[](tokens.length);
+        uint256[] memory amounts = new uint256[](tokens.length);
+        for (uint256 i = 0; i < tokens.length; i++) {
+            recipients[i] = refundTo;
+        }
+
+        IRelayRouterV3(ROUTER).cleanupErc20s(
+            tokens,
+            recipients,
+            amounts,
+            metadata
         );
     }
 

--- a/src/v3/interfaces/IRelayRouterV3.sol
+++ b/src/v3/interfaces/IRelayRouterV3.sol
@@ -17,4 +17,10 @@ interface IRelayRouterV3 {
         uint256[] calldata amounts,
         bytes calldata metadata
     ) external;
+
+    function cleanupNative(
+        uint256 amount,
+        address recipient,
+        bytes calldata metadata
+    ) external;
 }

--- a/src/v3/interfaces/IRelayRouterV3.sol
+++ b/src/v3/interfaces/IRelayRouterV3.sol
@@ -18,9 +18,4 @@ interface IRelayRouterV3 {
         bytes calldata metadata
     ) external;
 
-    function cleanupNative(
-        uint256 amount,
-        address recipient,
-        bytes calldata metadata
-    ) external;
 }

--- a/src/v3/interfaces/IRelayRouterV3.sol
+++ b/src/v3/interfaces/IRelayRouterV3.sol
@@ -10,4 +10,11 @@ interface IRelayRouterV3 {
         address nftRecipient,
         bytes calldata metadata
     ) external payable returns (Result[] memory returnData);
+
+    function cleanupErc20s(
+        address[] calldata tokens,
+        address[] calldata recipients,
+        uint256[] calldata amounts,
+        bytes calldata metadata
+    ) external;
 }

--- a/test/mocks/TestERC3009.sol
+++ b/test/mocks/TestERC3009.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.13;
+
+import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import {ECDSA} from "@openzeppelin/contracts/utils/cryptography/ECDSA.sol";
+import {EIP712} from "@openzeppelin/contracts/utils/cryptography/EIP712.sol";
+
+/// @dev Minimal EIP-3009 token used to test receiveWithAuthorization flows.
+contract TestERC3009 is ERC20, EIP712 {
+    bytes32 private constant _RECEIVE_WITH_AUTHORIZATION_TYPEHASH = keccak256(
+        "ReceiveWithAuthorization(address from,address to,uint256 value,uint256 validAfter,uint256 validBefore,bytes32 nonce)"
+    );
+
+    mapping(address authorizer => mapping(bytes32 nonce => bool used)) public authorizationState;
+
+    constructor() ERC20("Test3009", "TST3009") EIP712("Test3009", "1") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function DOMAIN_SEPARATOR() external view returns (bytes32) {
+        return _domainSeparatorV4();
+    }
+
+    function receiveWithAuthorization(
+        address from,
+        address to,
+        uint256 value,
+        uint256 validAfter,
+        uint256 validBefore,
+        bytes32 nonce,
+        uint8 v,
+        bytes32 r,
+        bytes32 s
+    ) external {
+        require(msg.sender == to, "caller must be payee");
+        require(block.timestamp > validAfter, "authorization not yet valid");
+        require(block.timestamp < validBefore, "authorization expired");
+        require(!authorizationState[from][nonce], "authorization used");
+
+        bytes32 digest = _hashTypedDataV4(
+            keccak256(abi.encode(_RECEIVE_WITH_AUTHORIZATION_TYPEHASH, from, to, value, validAfter, validBefore, nonce))
+        );
+        require(ECDSA.recover(digest, v, r, s) == from, "invalid signature");
+
+        authorizationState[from][nonce] = true;
+        _transfer(from, to, value);
+    }
+}

--- a/test/v3/RouterAndApprovalV3Test.sol
+++ b/test/v3/RouterAndApprovalV3Test.sol
@@ -1349,7 +1349,7 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
         tokens[0] = address(token);
 
         vm.prank(bob.addr);
-        approvalProxy.permit3009TransferAndMulticall(
+        approvalProxy.permit3009TransferAndMulticall{value: 1 ether}(
             permits,
             tokens,
             emptyCalls,
@@ -1361,6 +1361,8 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
 
         assertEq(token.balanceOf(alice.addr), amount);
         assertEq(token.balanceOf(address(router)), 0);
+        assertEq(address(router).balance, 0);
+        assertEq(address(approvalProxy).balance, 0);
 
         // A subsequent attacker-controlled multicall cannot spend the funds.
         Call3Value[] memory attackerCalls = new Call3Value[](1);

--- a/test/v3/RouterAndApprovalV3Test.sol
+++ b/test/v3/RouterAndApprovalV3Test.sol
@@ -16,6 +16,7 @@ import {RelayRouterV3} from "../../src/v3/RelayRouterV3.sol";
 import {BaseTest} from "../base/BaseTest.sol";
 import {IUniswapV2Router01} from "../interfaces/IUniswapV2Router02.sol";
 import {NoOpERC20} from "../mocks/NoOpERC20.sol";
+import {TestERC3009} from "../mocks/TestERC3009.sol";
 import {TestERC20Permit} from "../mocks/TestERC20Permit.sol";
 import {TestERC721} from "../mocks/TestERC721.sol";
 import {TestERC721_ERC20PaymentToken} from "../mocks/TestERC721_ERC20PaymentToken.sol";
@@ -50,6 +51,10 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
     bytes32 public constant _RELAYER_WITNESS_TYPEHASH =
         keccak256(
             "RelayerWitness(address relayer,address refundTo,address nftRecipient,bytes metadata,Call3Value[] call3Values)Call3Value(address target,bool allowFailure,uint256 value,bytes callData)"
+        );
+    bytes32 public constant _MULTICALL_AUTHORIZATION_TYPEHASH =
+        keccak256(
+            "MulticallAuthorization(address from,address relayer,address refundTo,address nftRecipient,bytes metadata,Call3Value[] calls)Call3Value(address target,bool allowFailure,uint256 value,bytes callData)"
         );
     bytes32 public constant _PERMIT2_FULL_RELAYER_WITNESS_TYPEHASH =
         keccak256(
@@ -1044,16 +1049,14 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
 
     function testApprovalProxy__Permit3009TransferAndMulticall() public {
         uint256 amount = 1000 * 10 ** 6;
-
-        // Deal alice some USDC
-
-        deal(USDC, alice.addr, amount);
+        TestERC3009 token = new TestERC3009();
+        token.mint(alice.addr, amount);
 
         // Encode router calls
 
         Call3Value[] memory calls = new Call3Value[](1);
         calls[0] = Call3Value({
-            target: address(USDC),
+            target: address(token),
             allowFailure: false,
             value: 0,
             callData: abi.encodeWithSelector(
@@ -1063,16 +1066,25 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
             )
         });
 
-        bytes32 witness = _getRelayerWitnessHash(
+        bytes32 authorizationDigest = _getMulticallAuthorizationDigest(
+            alice.addr,
             alice.addr,
             alice.addr,
             alice.addr,
             bytes(""),
             calls
         );
+        (uint8 authorizationV, bytes32 authorizationR, bytes32 authorizationS) =
+            vm.sign(alice.key, authorizationDigest);
+        bytes memory multicallSignature = bytes.concat(
+            authorizationR,
+            authorizationS,
+            bytes1(authorizationV)
+        );
         uint256 validBefore = block.timestamp + 100;
 
-        // Generate permit
+        // Generate an ERC3009 authorization whose nonce is the signed
+        // multicall authorization digest.
 
         bytes32 structHash = keccak256(
             abi.encode(
@@ -1082,12 +1094,11 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
                 amount,
                 0,
                 validBefore,
-                witness
+                authorizationDigest
             )
         );
         bytes32 eip712PermitHash = _hashTypedData(
-            // The only purpose of the conversion is to be able to call "DOMAIN_SEPARATOR"
-            TestERC20Permit(USDC).DOMAIN_SEPARATOR(),
+            token.DOMAIN_SEPARATOR(),
             structHash
         );
         (uint8 v, bytes32 r, bytes32 s) = vm.sign(alice.key, eip712PermitHash);
@@ -1103,30 +1114,80 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
             s: s
         });
         address[] memory tokens = new address[](1);
-        tokens[0] = USDC;
+        tokens[0] = address(token);
 
-        // Any changes in the call parameters should result in a failure
+        // Any changes in the signed execution parameters should result in a
+        // failure before the ERC3009 authorization is consumed.
 
         vm.prank(bob.addr);
-        vm.expectRevert("FiatTokenV2: invalid signature");
+        vm.expectRevert(
+            RelayApprovalProxyV3.InvalidMulticallSignature.selector
+        );
         approvalProxy.permit3009TransferAndMulticall(
+            alice.addr,
             permits,
             tokens,
             calls,
-            bob.addr,
             alice.addr,
+            alice.addr,
+            bytes(""),
+            multicallSignature
+        );
+
+        bytes memory signedCallData = calls[0].callData;
+        calls[0].callData = abi.encodeWithSelector(
+            IERC20.transfer.selector,
+            cal.addr,
+            amount
+        );
+        vm.prank(alice.addr);
+        vm.expectRevert(
+            RelayApprovalProxyV3.InvalidMulticallSignature.selector
+        );
+        approvalProxy.permit3009TransferAndMulticall(
+            alice.addr,
+            permits,
+            tokens,
+            calls,
+            alice.addr,
+            alice.addr,
+            bytes(""),
+            multicallSignature
+        );
+        calls[0].callData = signedCallData;
+
+        // The ERC3009 authorization cannot be used without the explicit
+        // multicall authorization signature.
+
+        vm.prank(alice.addr);
+        vm.expectRevert(
+            RelayApprovalProxyV3.InvalidMulticallSignature.selector
+        );
+        approvalProxy.permit3009TransferAndMulticall(
+            alice.addr,
+            permits,
+            tokens,
+            calls,
+            alice.addr,
+            alice.addr,
+            bytes(""),
             bytes("")
         );
 
         vm.prank(alice.addr);
         approvalProxy.permit3009TransferAndMulticall(
+            alice.addr,
             permits,
             tokens,
             calls,
             alice.addr,
             alice.addr,
-            bytes("")
+            bytes(""),
+            multicallSignature
         );
+
+        assertEq(token.balanceOf(alice.addr), 0);
+        assertEq(token.balanceOf(bob.addr), amount);
     }
 
     // Utility methods
@@ -1149,6 +1210,38 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
         }
 
         return keccak256(abi.encodePacked(callHashes));
+    }
+
+    function _getMulticallAuthorizationDigest(
+        address user,
+        address relayer,
+        address refundTo,
+        address nftRecipient,
+        bytes memory metadata,
+        Call3Value[] memory calls
+    ) internal view returns (bytes32) {
+        bytes32 domainSeparator = keccak256(
+            abi.encode(
+                _DOMAIN_TYPEHASH,
+                keccak256(bytes("RelayApprovalProxyV3")),
+                keccak256(bytes("1")),
+                block.chainid,
+                address(approvalProxy)
+            )
+        );
+        bytes32 structHash = keccak256(
+            abi.encode(
+                _MULTICALL_AUTHORIZATION_TYPEHASH,
+                user,
+                relayer,
+                refundTo,
+                nftRecipient,
+                keccak256(metadata),
+                _getCallsHash(calls)
+            )
+        );
+
+        return _hashTypedData(domainSeparator, structHash);
     }
 
     function _getRelayerWitnessHash(

--- a/test/v3/RouterAndApprovalV3Test.sol
+++ b/test/v3/RouterAndApprovalV3Test.sol
@@ -52,9 +52,13 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
         keccak256(
             "RelayerWitness(address relayer,address refundTo,address nftRecipient,bytes metadata,Call3Value[] call3Values)Call3Value(address target,bool allowFailure,uint256 value,bytes callData)"
         );
+    bytes32 public constant _FUNDING_AUTHORIZATION_TYPEHASH =
+        keccak256(
+            "FundingAuthorization(address token,address from,uint256 value,uint256 validAfter,uint256 validBefore)"
+        );
     bytes32 public constant _MULTICALL_AUTHORIZATION_TYPEHASH =
         keccak256(
-            "MulticallAuthorization(address from,address relayer,address refundTo,address nftRecipient,bytes metadata,Call3Value[] calls)Call3Value(address target,bool allowFailure,uint256 value,bytes callData)"
+            "MulticallAuthorization(address from,address relayer,address refundTo,address nftRecipient,bytes metadata,uint256 fundingIndex,Call3Value[] calls,FundingAuthorization[] funding)Call3Value(address target,bool allowFailure,uint256 value,bytes callData)FundingAuthorization(address token,address from,uint256 value,uint256 validAfter,uint256 validBefore)"
         );
     bytes32 public constant _PERMIT2_FULL_RELAYER_WITNESS_TYPEHASH =
         keccak256(
@@ -1077,13 +1081,40 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
             )
         });
 
+        uint256 validBefore = block.timestamp + 100;
+        Permit3009[] memory permits = new Permit3009[](2);
+        permits[0] = Permit3009({
+            from: alice.addr,
+            value: amount,
+            validAfter: 0,
+            validBefore: validBefore,
+            v: 0,
+            r: bytes32(0),
+            s: bytes32(0)
+        });
+        permits[1] = Permit3009({
+            from: bob.addr,
+            value: amount,
+            validAfter: 0,
+            validBefore: validBefore,
+            v: 0,
+            r: bytes32(0),
+            s: bytes32(0)
+        });
+        address[] memory tokens = new address[](2);
+        tokens[0] = address(aliceToken);
+        tokens[1] = address(bobToken);
+        bytes32 fundingHash = _getFundingHash(permits, tokens);
+
         bytes32 aliceAuthorizationDigest = _getMulticallAuthorizationDigest(
             alice.addr,
             alice.addr,
             alice.addr,
             alice.addr,
             bytes(""),
-            calls
+            calls,
+            fundingHash,
+            0
         );
         bytes32 bobAuthorizationDigest = _getMulticallAuthorizationDigest(
             bob.addr,
@@ -1091,7 +1122,9 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
             alice.addr,
             alice.addr,
             bytes(""),
-            calls
+            calls,
+            fundingHash,
+            1
         );
         (uint8 aliceAuthorizationV, bytes32 aliceAuthorizationR, bytes32 aliceAuthorizationS) =
             vm.sign(alice.key, aliceAuthorizationDigest);
@@ -1108,7 +1141,6 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
             bobAuthorizationS,
             bytes1(bobAuthorizationV)
         );
-        uint256 validBefore = block.timestamp + 100;
 
         // Generate ERC3009 authorizations whose nonces are the corresponding
         // signed multicall authorization digests.
@@ -1128,7 +1160,7 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
             aliceToken.DOMAIN_SEPARATOR(),
             aliceStructHash
         );
-        (uint8 aliceV, bytes32 aliceR, bytes32 aliceS) =
+        (permits[0].v, permits[0].r, permits[0].s) =
             vm.sign(alice.key, alicePermitHash);
 
         bytes32 bobStructHash = keccak256(
@@ -1146,31 +1178,8 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
             bobToken.DOMAIN_SEPARATOR(),
             bobStructHash
         );
-        (uint8 bobV, bytes32 bobR, bytes32 bobS) =
+        (permits[1].v, permits[1].r, permits[1].s) =
             vm.sign(bob.key, bobPermitHash);
-
-        Permit3009[] memory permits = new Permit3009[](2);
-        permits[0] = Permit3009({
-            from: alice.addr,
-            value: amount,
-            validAfter: 0,
-            validBefore: validBefore,
-            v: aliceV,
-            r: aliceR,
-            s: aliceS
-        });
-        permits[1] = Permit3009({
-            from: bob.addr,
-            value: amount,
-            validAfter: 0,
-            validBefore: validBefore,
-            v: bobV,
-            r: bobR,
-            s: bobS
-        });
-        address[] memory tokens = new address[](2);
-        tokens[0] = address(aliceToken);
-        tokens[1] = address(bobToken);
 
         bytes[] memory mismatchedMulticallSignatures = new bytes[](1);
         vm.expectRevert(RelayApprovalProxyV3.ArrayLengthsMismatch.selector);
@@ -1182,6 +1191,37 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
             alice.addr,
             bytes(""),
             mismatchedMulticallSignatures
+        );
+
+        // Every signature commits to the complete ordered funding batch, so
+        // an aligned subset cannot be submitted independently.
+        Permit3009[] memory subsetPermits = new Permit3009[](1);
+        subsetPermits[0] = permits[0];
+        address[] memory subsetTokens = new address[](1);
+        subsetTokens[0] = tokens[0];
+        bytes[] memory subsetSignatures = new bytes[](1);
+        subsetSignatures[0] = multicallSignatures[0];
+        vm.prank(alice.addr);
+        vm.expectRevert(
+            RelayApprovalProxyV3.InvalidMulticallSignature.selector
+        );
+        approvalProxy.permit3009TransferAndMulticall(
+            subsetPermits,
+            subsetTokens,
+            calls,
+            alice.addr,
+            alice.addr,
+            bytes(""),
+            subsetSignatures
+        );
+        assertFalse(
+            aliceToken.authorizationState(
+                alice.addr,
+                aliceAuthorizationDigest
+            )
+        );
+        assertFalse(
+            bobToken.authorizationState(bob.addr, bobAuthorizationDigest)
         );
 
         Permit3009[] memory emptyPermits = new Permit3009[](0);
@@ -1294,59 +1334,110 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
         assertEq(bobToken.balanceOf(address(router)), 0);
     }
 
-    function testApprovalProxy__Permit3009EmptyMulticallCleanup() public {
+    function testApprovalProxy__Permit3009DuplicateOwnerTokenAndEmptyMulticallCleanup()
+        public
+    {
         uint256 amount = 1000 * 10 ** 6;
         TestERC3009 token = new TestERC3009();
         token.mint(alice.addr, amount);
         Call3Value[] memory emptyCalls = new Call3Value[](0);
 
-        bytes32 authorizationDigest = _getMulticallAuthorizationDigest(
+        uint256 validBefore = block.timestamp + 100;
+        Permit3009[] memory permits = new Permit3009[](2);
+        permits[0] = Permit3009({
+            from: alice.addr,
+            value: amount / 2,
+            validAfter: 0,
+            validBefore: validBefore,
+            v: 0,
+            r: bytes32(0),
+            s: bytes32(0)
+        });
+        permits[1] = Permit3009({
+            from: alice.addr,
+            value: amount / 2,
+            validAfter: 0,
+            validBefore: validBefore,
+            v: 0,
+            r: bytes32(0),
+            s: bytes32(0)
+        });
+        address[] memory tokens = new address[](2);
+        tokens[0] = address(token);
+        tokens[1] = address(token);
+        bytes32 fundingHash = _getFundingHash(permits, tokens);
+
+        bytes32 firstAuthorizationDigest = _getMulticallAuthorizationDigest(
             alice.addr,
             bob.addr,
             alice.addr,
             alice.addr,
             bytes(""),
-            emptyCalls
+            emptyCalls,
+            fundingHash,
+            0
         );
-        (uint8 authorizationV, bytes32 authorizationR, bytes32 authorizationS) =
-            vm.sign(alice.key, authorizationDigest);
-        bytes[] memory multicallSignatures = new bytes[](1);
+        bytes32 secondAuthorizationDigest = _getMulticallAuthorizationDigest(
+            alice.addr,
+            bob.addr,
+            alice.addr,
+            alice.addr,
+            bytes(""),
+            emptyCalls,
+            fundingHash,
+            1
+        );
+        (uint8 firstV, bytes32 firstR, bytes32 firstS) =
+            vm.sign(alice.key, firstAuthorizationDigest);
+        (uint8 secondV, bytes32 secondR, bytes32 secondS) =
+            vm.sign(alice.key, secondAuthorizationDigest);
+        bytes[] memory multicallSignatures = new bytes[](2);
         multicallSignatures[0] = bytes.concat(
-            authorizationR,
-            authorizationS,
-            bytes1(authorizationV)
+            firstR,
+            firstS,
+            bytes1(firstV)
+        );
+        multicallSignatures[1] = bytes.concat(
+            secondR,
+            secondS,
+            bytes1(secondV)
         );
 
-        uint256 validBefore = block.timestamp + 100;
-        bytes32 structHash = keccak256(
+        bytes32 firstStructHash = keccak256(
             abi.encode(
                 _PERMIT3009_TYPEHASH,
                 alice.addr,
                 address(approvalProxy),
-                amount,
+                amount / 2,
                 0,
                 validBefore,
-                authorizationDigest
+                firstAuthorizationDigest
             )
         );
-        bytes32 permitHash = _hashTypedData(
+        bytes32 firstPermitHash = _hashTypedData(
             token.DOMAIN_SEPARATOR(),
-            structHash
+            firstStructHash
         );
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(alice.key, permitHash);
+        (permits[0].v, permits[0].r, permits[0].s) =
+            vm.sign(alice.key, firstPermitHash);
 
-        Permit3009[] memory permits = new Permit3009[](1);
-        permits[0] = Permit3009({
-            from: alice.addr,
-            value: amount,
-            validAfter: 0,
-            validBefore: validBefore,
-            v: v,
-            r: r,
-            s: s
-        });
-        address[] memory tokens = new address[](1);
-        tokens[0] = address(token);
+        bytes32 secondStructHash = keccak256(
+            abi.encode(
+                _PERMIT3009_TYPEHASH,
+                alice.addr,
+                address(approvalProxy),
+                amount / 2,
+                0,
+                validBefore,
+                secondAuthorizationDigest
+            )
+        );
+        bytes32 secondPermitHash = _hashTypedData(
+            token.DOMAIN_SEPARATOR(),
+            secondStructHash
+        );
+        (permits[1].v, permits[1].r, permits[1].s) =
+            vm.sign(alice.key, secondPermitHash);
 
         vm.prank(bob.addr);
         approvalProxy.permit3009TransferAndMulticall{value: 1 ether}(
@@ -1361,6 +1452,12 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
 
         assertEq(token.balanceOf(alice.addr), amount);
         assertEq(token.balanceOf(address(router)), 0);
+        assertTrue(
+            token.authorizationState(alice.addr, firstAuthorizationDigest)
+        );
+        assertTrue(
+            token.authorizationState(alice.addr, secondAuthorizationDigest)
+        );
         assertEq(address(router).balance, 0);
         assertEq(address(approvalProxy).balance, 0);
 
@@ -1410,13 +1507,36 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
         return keccak256(abi.encodePacked(callHashes));
     }
 
+    function _getFundingHash(
+        Permit3009[] memory permits,
+        address[] memory tokens
+    ) internal pure returns (bytes32) {
+        bytes32[] memory fundingHashes = new bytes32[](permits.length);
+        for (uint256 i = 0; i < permits.length; i++) {
+            fundingHashes[i] = keccak256(
+                abi.encode(
+                    _FUNDING_AUTHORIZATION_TYPEHASH,
+                    tokens[i],
+                    permits[i].from,
+                    permits[i].value,
+                    permits[i].validAfter,
+                    permits[i].validBefore
+                )
+            );
+        }
+
+        return keccak256(abi.encodePacked(fundingHashes));
+    }
+
     function _getMulticallAuthorizationDigest(
         address user,
         address relayer,
         address refundTo,
         address nftRecipient,
         bytes memory metadata,
-        Call3Value[] memory calls
+        Call3Value[] memory calls,
+        bytes32 fundingHash,
+        uint256 fundingIndex
     ) internal view returns (bytes32) {
         bytes32 domainSeparator = keccak256(
             abi.encode(
@@ -1435,7 +1555,9 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
                 refundTo,
                 nftRecipient,
                 keccak256(metadata),
-                _getCallsHash(calls)
+                fundingIndex,
+                _getCallsHash(calls),
+                fundingHash
             )
         );
 

--- a/test/v3/RouterAndApprovalV3Test.sol
+++ b/test/v3/RouterAndApprovalV3Test.sol
@@ -1049,14 +1049,16 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
 
     function testApprovalProxy__Permit3009TransferAndMulticall() public {
         uint256 amount = 1000 * 10 ** 6;
-        TestERC3009 token = new TestERC3009();
-        token.mint(alice.addr, amount);
+        TestERC3009 aliceToken = new TestERC3009();
+        TestERC3009 bobToken = new TestERC3009();
+        aliceToken.mint(alice.addr, amount);
+        bobToken.mint(bob.addr, amount);
 
         // Encode router calls
 
-        Call3Value[] memory calls = new Call3Value[](1);
+        Call3Value[] memory calls = new Call3Value[](2);
         calls[0] = Call3Value({
-            target: address(token),
+            target: address(aliceToken),
             allowFailure: false,
             value: 0,
             callData: abi.encodeWithSelector(
@@ -1065,8 +1067,18 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
                 amount
             )
         });
+        calls[1] = Call3Value({
+            target: address(bobToken),
+            allowFailure: false,
+            value: 0,
+            callData: abi.encodeWithSelector(
+                IERC20.transfer.selector,
+                cal.addr,
+                amount
+            )
+        });
 
-        bytes32 authorizationDigest = _getMulticallAuthorizationDigest(
+        bytes32 aliceAuthorizationDigest = _getMulticallAuthorizationDigest(
             alice.addr,
             alice.addr,
             alice.addr,
@@ -1074,19 +1086,35 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
             bytes(""),
             calls
         );
-        (uint8 authorizationV, bytes32 authorizationR, bytes32 authorizationS) =
-            vm.sign(alice.key, authorizationDigest);
-        bytes memory multicallSignature = bytes.concat(
-            authorizationR,
-            authorizationS,
-            bytes1(authorizationV)
+        bytes32 bobAuthorizationDigest = _getMulticallAuthorizationDigest(
+            bob.addr,
+            alice.addr,
+            alice.addr,
+            alice.addr,
+            bytes(""),
+            calls
+        );
+        (uint8 aliceAuthorizationV, bytes32 aliceAuthorizationR, bytes32 aliceAuthorizationS) =
+            vm.sign(alice.key, aliceAuthorizationDigest);
+        (uint8 bobAuthorizationV, bytes32 bobAuthorizationR, bytes32 bobAuthorizationS) =
+            vm.sign(bob.key, bobAuthorizationDigest);
+        bytes[] memory multicallSignatures = new bytes[](2);
+        multicallSignatures[0] = bytes.concat(
+            aliceAuthorizationR,
+            aliceAuthorizationS,
+            bytes1(aliceAuthorizationV)
+        );
+        multicallSignatures[1] = bytes.concat(
+            bobAuthorizationR,
+            bobAuthorizationS,
+            bytes1(bobAuthorizationV)
         );
         uint256 validBefore = block.timestamp + 100;
 
-        // Generate an ERC3009 authorization whose nonce is the signed
-        // multicall authorization digest.
+        // Generate ERC3009 authorizations whose nonces are the corresponding
+        // signed multicall authorization digests.
 
-        bytes32 structHash = keccak256(
+        bytes32 aliceStructHash = keccak256(
             abi.encode(
                 _PERMIT3009_TYPEHASH,
                 alice.addr,
@@ -1094,30 +1122,72 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
                 amount,
                 0,
                 validBefore,
-                authorizationDigest
+                aliceAuthorizationDigest
             )
         );
-        bytes32 eip712PermitHash = _hashTypedData(
-            token.DOMAIN_SEPARATOR(),
-            structHash
+        bytes32 alicePermitHash = _hashTypedData(
+            aliceToken.DOMAIN_SEPARATOR(),
+            aliceStructHash
         );
-        (uint8 v, bytes32 r, bytes32 s) = vm.sign(alice.key, eip712PermitHash);
+        (uint8 aliceV, bytes32 aliceR, bytes32 aliceS) =
+            vm.sign(alice.key, alicePermitHash);
 
-        Permit3009[] memory permits = new Permit3009[](1);
+        bytes32 bobStructHash = keccak256(
+            abi.encode(
+                _PERMIT3009_TYPEHASH,
+                bob.addr,
+                address(approvalProxy),
+                amount,
+                0,
+                validBefore,
+                bobAuthorizationDigest
+            )
+        );
+        bytes32 bobPermitHash = _hashTypedData(
+            bobToken.DOMAIN_SEPARATOR(),
+            bobStructHash
+        );
+        (uint8 bobV, bytes32 bobR, bytes32 bobS) =
+            vm.sign(bob.key, bobPermitHash);
+
+        Permit3009[] memory permits = new Permit3009[](2);
         permits[0] = Permit3009({
             from: alice.addr,
             value: amount,
             validAfter: 0,
             validBefore: validBefore,
-            v: v,
-            r: r,
-            s: s
+            v: aliceV,
+            r: aliceR,
+            s: aliceS
         });
-        address[] memory tokens = new address[](1);
-        tokens[0] = address(token);
+        permits[1] = Permit3009({
+            from: bob.addr,
+            value: amount,
+            validAfter: 0,
+            validBefore: validBefore,
+            v: bobV,
+            r: bobR,
+            s: bobS
+        });
+        address[] memory tokens = new address[](2);
+        tokens[0] = address(aliceToken);
+        tokens[1] = address(bobToken);
+
+        bytes[] memory mismatchedMulticallSignatures = new bytes[](1);
+        vm.expectRevert(RelayApprovalProxyV3.ArrayLengthsMismatch.selector);
+        approvalProxy.permit3009TransferAndMulticall(
+            permits,
+            tokens,
+            calls,
+            alice.addr,
+            alice.addr,
+            bytes(""),
+            mismatchedMulticallSignatures
+        );
 
         Permit3009[] memory emptyPermits = new Permit3009[](0);
         address[] memory emptyTokens = new address[](0);
+        bytes[] memory emptyMulticallSignatures = new bytes[](0);
         vm.expectRevert(RelayApprovalProxyV3.PermitsCannotBeEmpty.selector);
         approvalProxy.permit3009TransferAndMulticall(
             emptyPermits,
@@ -1126,7 +1196,7 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
             alice.addr,
             alice.addr,
             bytes(""),
-            multicallSignature
+            emptyMulticallSignatures
         );
 
         // Any changes in the signed execution parameters should result in a
@@ -1143,7 +1213,7 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
             alice.addr,
             alice.addr,
             bytes(""),
-            multicallSignature
+            multicallSignatures
         );
 
         bytes memory signedCallData = calls[0].callData;
@@ -1163,13 +1233,14 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
             alice.addr,
             alice.addr,
             bytes(""),
-            multicallSignature
+            multicallSignatures
         );
         calls[0].callData = signedCallData;
 
         // The ERC3009 authorization cannot be used without the explicit
         // multicall authorization signature.
 
+        bytes[] memory missingMulticallSignatures = new bytes[](2);
         vm.prank(alice.addr);
         vm.expectRevert(
             RelayApprovalProxyV3.InvalidMulticallSignature.selector
@@ -1181,8 +1252,28 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
             alice.addr,
             alice.addr,
             bytes(""),
-            bytes("")
+            missingMulticallSignatures
         );
+
+        // Each signature must correspond to the permit at the same index.
+        bytes memory aliceMulticallSignature = multicallSignatures[0];
+        multicallSignatures[0] = multicallSignatures[1];
+        multicallSignatures[1] = aliceMulticallSignature;
+        vm.prank(alice.addr);
+        vm.expectRevert(
+            RelayApprovalProxyV3.InvalidMulticallSignature.selector
+        );
+        approvalProxy.permit3009TransferAndMulticall(
+            permits,
+            tokens,
+            calls,
+            alice.addr,
+            alice.addr,
+            bytes(""),
+            multicallSignatures
+        );
+        multicallSignatures[1] = multicallSignatures[0];
+        multicallSignatures[0] = aliceMulticallSignature;
 
         vm.prank(alice.addr);
         approvalProxy.permit3009TransferAndMulticall(
@@ -1192,11 +1283,13 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
             alice.addr,
             alice.addr,
             bytes(""),
-            multicallSignature
+            multicallSignatures
         );
 
-        assertEq(token.balanceOf(alice.addr), 0);
-        assertEq(token.balanceOf(bob.addr), amount);
+        assertEq(aliceToken.balanceOf(alice.addr), 0);
+        assertEq(aliceToken.balanceOf(bob.addr), amount);
+        assertEq(bobToken.balanceOf(bob.addr), 0);
+        assertEq(bobToken.balanceOf(cal.addr), amount);
     }
 
     // Utility methods

--- a/test/v3/RouterAndApprovalV3Test.sol
+++ b/test/v3/RouterAndApprovalV3Test.sol
@@ -1116,6 +1116,19 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
         address[] memory tokens = new address[](1);
         tokens[0] = address(token);
 
+        Permit3009[] memory emptyPermits = new Permit3009[](0);
+        address[] memory emptyTokens = new address[](0);
+        vm.expectRevert(RelayApprovalProxyV3.PermitsCannotBeEmpty.selector);
+        approvalProxy.permit3009TransferAndMulticall(
+            emptyPermits,
+            emptyTokens,
+            calls,
+            alice.addr,
+            alice.addr,
+            bytes(""),
+            multicallSignature
+        );
+
         // Any changes in the signed execution parameters should result in a
         // failure before the ERC3009 authorization is consumed.
 
@@ -1124,7 +1137,6 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
             RelayApprovalProxyV3.InvalidMulticallSignature.selector
         );
         approvalProxy.permit3009TransferAndMulticall(
-            alice.addr,
             permits,
             tokens,
             calls,
@@ -1145,7 +1157,6 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
             RelayApprovalProxyV3.InvalidMulticallSignature.selector
         );
         approvalProxy.permit3009TransferAndMulticall(
-            alice.addr,
             permits,
             tokens,
             calls,
@@ -1164,7 +1175,6 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
             RelayApprovalProxyV3.InvalidMulticallSignature.selector
         );
         approvalProxy.permit3009TransferAndMulticall(
-            alice.addr,
             permits,
             tokens,
             calls,
@@ -1176,7 +1186,6 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
 
         vm.prank(alice.addr);
         approvalProxy.permit3009TransferAndMulticall(
-            alice.addr,
             permits,
             tokens,
             calls,

--- a/test/v3/RouterAndApprovalV3Test.sol
+++ b/test/v3/RouterAndApprovalV3Test.sol
@@ -245,15 +245,13 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
         assertEq(erc20_2.balanceOf(bob.addr), 0.15 ether);
         assertEq(erc20_3.balanceOf(bob.addr), 0.2 ether);
 
-        // Any other funds are left in the router
-        assertEq(erc20_1.balanceOf(address(router)), 0.07 ether);
-        assertEq(erc20_2.balanceOf(address(router)), 0.05 ether);
-        assertEq(erc20_3.balanceOf(address(router)), 0.1 ether);
-
-        // All tokens specified by alice were spent from her wallet
-        assertEq(erc20_1.balanceOf(alice.addr), 0.9 ether);
-        assertEq(erc20_2.balanceOf(alice.addr), 0.8 ether);
-        assertEq(erc20_3.balanceOf(alice.addr), 0.7 ether);
+        // Any unspent funds are returned to the refund recipient
+        assertEq(erc20_1.balanceOf(address(router)), 0);
+        assertEq(erc20_2.balanceOf(address(router)), 0);
+        assertEq(erc20_3.balanceOf(address(router)), 0);
+        assertEq(erc20_1.balanceOf(alice.addr), 0.97 ether);
+        assertEq(erc20_2.balanceOf(alice.addr), 0.85 ether);
+        assertEq(erc20_3.balanceOf(alice.addr), 0.8 ether);
     }
 
     function testRouter__Multicall__SwapWETHForUSDC() public {
@@ -700,7 +698,7 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
             callData: abi.encodeWithSelector(
                 IERC20.transfer.selector,
                 bob.addr,
-                1 ether
+                0.4 ether
             )
         });
 
@@ -724,8 +722,9 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
             bytes("")
         );
 
-        assertEq(erc20_permit.balanceOf(alice.addr), 0);
-        assertEq(erc20_permit.balanceOf(bob.addr), 1 ether);
+        assertEq(erc20_permit.balanceOf(alice.addr), 0.6 ether);
+        assertEq(erc20_permit.balanceOf(bob.addr), 0.4 ether);
+        assertEq(erc20_permit.balanceOf(address(router)), 0);
     }
 
     function testApprovalProxy__PermitTransferAndMulticall__FrontrunEip2612()
@@ -1064,7 +1063,7 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
             callData: abi.encodeWithSelector(
                 IERC20.transfer.selector,
                 bob.addr,
-                amount
+                amount / 2
             )
         });
         calls[1] = Call3Value({
@@ -1074,7 +1073,7 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
             callData: abi.encodeWithSelector(
                 IERC20.transfer.selector,
                 cal.addr,
-                amount
+                amount / 2
             )
         });
 
@@ -1286,10 +1285,105 @@ contract RouterAndApprovalV3Test is BaseTest, EIP712 {
             multicallSignatures
         );
 
-        assertEq(aliceToken.balanceOf(alice.addr), 0);
-        assertEq(aliceToken.balanceOf(bob.addr), amount);
+        assertEq(aliceToken.balanceOf(alice.addr), amount / 2);
+        assertEq(aliceToken.balanceOf(bob.addr), amount / 2);
         assertEq(bobToken.balanceOf(bob.addr), 0);
-        assertEq(bobToken.balanceOf(cal.addr), amount);
+        assertEq(bobToken.balanceOf(alice.addr), amount / 2);
+        assertEq(bobToken.balanceOf(cal.addr), amount / 2);
+        assertEq(aliceToken.balanceOf(address(router)), 0);
+        assertEq(bobToken.balanceOf(address(router)), 0);
+    }
+
+    function testApprovalProxy__Permit3009EmptyMulticallCleanup() public {
+        uint256 amount = 1000 * 10 ** 6;
+        TestERC3009 token = new TestERC3009();
+        token.mint(alice.addr, amount);
+        Call3Value[] memory emptyCalls = new Call3Value[](0);
+
+        bytes32 authorizationDigest = _getMulticallAuthorizationDigest(
+            alice.addr,
+            bob.addr,
+            alice.addr,
+            alice.addr,
+            bytes(""),
+            emptyCalls
+        );
+        (uint8 authorizationV, bytes32 authorizationR, bytes32 authorizationS) =
+            vm.sign(alice.key, authorizationDigest);
+        bytes[] memory multicallSignatures = new bytes[](1);
+        multicallSignatures[0] = bytes.concat(
+            authorizationR,
+            authorizationS,
+            bytes1(authorizationV)
+        );
+
+        uint256 validBefore = block.timestamp + 100;
+        bytes32 structHash = keccak256(
+            abi.encode(
+                _PERMIT3009_TYPEHASH,
+                alice.addr,
+                address(approvalProxy),
+                amount,
+                0,
+                validBefore,
+                authorizationDigest
+            )
+        );
+        bytes32 permitHash = _hashTypedData(
+            token.DOMAIN_SEPARATOR(),
+            structHash
+        );
+        (uint8 v, bytes32 r, bytes32 s) = vm.sign(alice.key, permitHash);
+
+        Permit3009[] memory permits = new Permit3009[](1);
+        permits[0] = Permit3009({
+            from: alice.addr,
+            value: amount,
+            validAfter: 0,
+            validBefore: validBefore,
+            v: v,
+            r: r,
+            s: s
+        });
+        address[] memory tokens = new address[](1);
+        tokens[0] = address(token);
+
+        vm.prank(bob.addr);
+        approvalProxy.permit3009TransferAndMulticall(
+            permits,
+            tokens,
+            emptyCalls,
+            alice.addr,
+            alice.addr,
+            bytes(""),
+            multicallSignatures
+        );
+
+        assertEq(token.balanceOf(alice.addr), amount);
+        assertEq(token.balanceOf(address(router)), 0);
+
+        // A subsequent attacker-controlled multicall cannot spend the funds.
+        Call3Value[] memory attackerCalls = new Call3Value[](1);
+        attackerCalls[0] = Call3Value({
+            target: address(token),
+            allowFailure: true,
+            value: 0,
+            callData: abi.encodeWithSelector(
+                IERC20.transfer.selector,
+                bob.addr,
+                amount
+            )
+        });
+        vm.prank(bob.addr);
+        router.multicall(
+            attackerCalls,
+            bob.addr,
+            bob.addr,
+            bytes("")
+        );
+
+        assertEq(token.balanceOf(bob.addr), 0);
+        assertEq(token.balanceOf(address(router)), 0);
     }
 
     // Utility methods


### PR DESCRIPTION
## Summary
- require separate EIP-712 `MulticallAuthorization` signatures for ERC-3009 multicalls
- bind every authorization to the complete ordered funding batch (`token`, `from`, `value`, `validAfter`, and `validBefore`) so aligned subsets or reordered batches are invalid
- include the funding index in each authorization digest, producing distinct ERC-3009 nonces for duplicate owner/token entries
- use each authorization digest as the corresponding ERC-3009 nonce, binding every permit to the relayer, recipients, metadata, and exact call targets/values/data
- require `multicallSignatures.length == permits.length` and verify each signature against `permits[i].from`
- explicitly sweep unspent router ERC-20 balances to `refundTo` after ERC-2612, Permit2, and ERC-3009 permit multicalls; native refunds remain handled by `RelayRouterV3.multicall`
- reject empty ERC-3009 permit batches
- cover subset submission, signature reordering, duplicate owner/token permits, and an empty signed multicall followed by an attacker-controlled multicall

## Integration impact
`permit3009TransferAndMulticall` now accepts `bytes[] multicallSignatures`, and the signed `MulticallAuthorization` includes `fundingIndex` and the complete `FundingAuthorization[] funding` array. This requires an ABI/client update and a new approval-proxy deployment.

EIP-712 domain:
- name: `RelayApprovalProxyV3`
- version: `1`

## Tests
- `forge build`
- `forge test --match-contract RouterAndApprovalV3Test --match-test testApprovalProxy__PermitTransferAndMulticall_Eip2612 -vv`
- `forge test --match-contract RouterAndApprovalV3Test --match-test testApprovalProxy__PermitTransferAndMulticall__FrontrunEip2612 -vv`
- `forge test --match-contract RouterAndApprovalV3Test --match-test testApprovalProxy__Permit3009TransferAndMulticall -vv`
- `forge test --match-contract RouterAndApprovalV3Test --match-test testApprovalProxy__Permit3009DuplicateOwnerTokenAndEmptyMulticallCleanup -vv`