### PR TITLE
fix: emit FundsMovement on ViaCall cleanups, harden proxy rescue path

### DIFF
--- a/src/v3/RelayApprovalProxyV3.sol
+++ b/src/v3/RelayApprovalProxyV3.sol
@@ -26,6 +26,9 @@ contract RelayApprovalProxyV3 is Ownable {
     /// @notice Revert if the array lengths do not match
     error ArrayLengthsMismatch();
 
+    /// @notice Revert if a constructor argument is the zero address
+    error ConstructorArgCannotBeZeroAddress();
+
     /// @notice Revert if the native transfer fails
     error NativeTransferFailed();
 
@@ -61,6 +64,16 @@ contract RelayApprovalProxyV3 is Ownable {
     receive() external payable {}
 
     constructor(address _owner, address _router, address _permit2) {
+        // `ROUTER` and `PERMIT2` are immutable and `_owner` gates the only
+        // rescue function, so a zero argument is unrecoverable post-deploy
+        if (
+            _owner == address(0) ||
+            _router == address(0) ||
+            _permit2 == address(0)
+        ) {
+            revert ConstructorArgCannotBeZeroAddress();
+        }
+
         _initializeOwner(_owner);
         ROUTER = _router;
         PERMIT2 = IPermit2(_permit2);
@@ -418,10 +431,11 @@ contract RelayApprovalProxyV3 is Ownable {
         bool success;
         assembly {
             // Save gas by avoiding copying the return data to memory.
-            // Provide at most 100k gas to the internal call, which is
-            // more than enough to cover common use-cases of logic for
-            // receiving native tokens (eg. SCW payable fallbacks).
-            success := call(100000, to, value, 0, 0, 0, 0)
+            // All remaining gas is forwarded: `_send` is only reachable from
+            // `withdraw`, which is `onlyOwner`, and the owner may be a multisig
+            // or smart contract wallet whose receive hook exceeds a fixed
+            // stipend. Capping it there would strand the native balance.
+            success := call(gas(), to, value, 0, 0, 0, 0)
         }
 
         if (!success) {

--- a/src/v3/RelayRouterV3.sol
+++ b/src/v3/RelayRouterV3.sol
@@ -46,6 +46,17 @@ contract RelayRouterV3 is Multicall3, ReentrancyGuardMsgSender {
     event SolverNativeTransfer(address to, uint256 amount);
 
     /// @notice Emitted on any explicit movement of funds
+    /// @param from The address the funds left
+    /// @param to The counterparty of the movement. For direct transfers
+    ///        (`multicall`, `cleanupErc20s`, `cleanupNative`,
+    ///        `cleanupNativeViaCall`) this is the address the funds were sent
+    ///        to. For `cleanupErc20sViaCall` it is the call target the router
+    ///        approved, which spends the allowance from within its own code
+    ///        and may deliver the tokens to a different final recipient that
+    ///        the router cannot observe.
+    /// @param currency The token moved, or address(0) for native tokens
+    /// @param amount The amount that actually left `from`
+    /// @param metadata Additional data associated with the movement
     event FundsMovement(
         address from,
         address to,
@@ -156,7 +167,10 @@ contract RelayRouterV3 is Multicall3, ReentrancyGuardMsgSender {
     /// @param amounts The amounts to send
     /// @dev    Emits `FundsMovement` with empty metadata: unlike `cleanupErc20s`
     ///         this entrypoint takes no metadata argument, so movements cannot be
-    ///         correlated off-chain by request id.
+    ///         correlated off-chain by request id. The event's `to` is the call
+    ///         target the allowance was granted to, not necessarily the final
+    ///         token recipient — the target may `transferFrom` the router to a
+    ///         third party, which the router cannot observe.
     function cleanupErc20sViaCall(
         address[] calldata tokens,
         address[] calldata tos,

--- a/src/v3/RelayRouterV3.sol
+++ b/src/v3/RelayRouterV3.sol
@@ -154,6 +154,9 @@ contract RelayRouterV3 is Multicall3, ReentrancyGuardMsgSender {
     /// @param tos The target addresses for the calls
     /// @param datas The data for the calls
     /// @param amounts The amounts to send
+    /// @dev    Emits `FundsMovement` with empty metadata: unlike `cleanupErc20s`
+    ///         this entrypoint takes no metadata argument, so movements cannot be
+    ///         correlated off-chain by request id.
     function cleanupErc20sViaCall(
         address[] calldata tokens,
         address[] calldata tos,
@@ -174,10 +177,10 @@ contract RelayRouterV3 is Multicall3, ReentrancyGuardMsgSender {
             address to = tos[i];
             bytes calldata data = datas[i];
 
+            uint256 balanceBefore = IERC20(token).balanceOf(address(this));
+
             // Get the amount to transfer
-            uint256 amount = amounts[i] == 0
-                ? IERC20(token).balanceOf(address(this))
-                : amounts[i];
+            uint256 amount = amounts[i] == 0 ? balanceBefore : amounts[i];
 
             if (amount > 0) {
                 // Approve the target for the call. Use safeApproveWithRetry to
@@ -191,6 +194,20 @@ contract RelayRouterV3 is Multicall3, ReentrancyGuardMsgSender {
                 (bool success, ) = to.call(data);
                 if (!success) {
                     revert CallFailed();
+                }
+
+                // Emit the amount the target actually consumed, which can be
+                // less than the amount approved. `to` is the approved spender,
+                // not necessarily the final holder of the tokens.
+                uint256 balanceAfter = IERC20(token).balanceOf(address(this));
+                if (balanceBefore > balanceAfter) {
+                    emit FundsMovement(
+                        address(this),
+                        to,
+                        token,
+                        balanceBefore - balanceAfter,
+                        ""
+                    );
                 }
             }
         }
@@ -232,6 +249,8 @@ contract RelayRouterV3 is Multicall3, ReentrancyGuardMsgSender {
     /// @param amount The amount of native tokens to transfer
     /// @param to The target address of the call
     /// @param data The data for the call
+    /// @dev    Emits `FundsMovement` with empty metadata, and does not emit
+    ///         `SolverNativeTransfer` (unlike `cleanupNative`).
     function cleanupNativeViaCall(
         uint256 amount,
         address to,
@@ -244,6 +263,14 @@ contract RelayRouterV3 is Multicall3, ReentrancyGuardMsgSender {
             if (!success) {
                 revert CallFailed();
             }
+
+            emit FundsMovement(
+                address(this),
+                to,
+                address(0),
+                amountToTransfer,
+                ""
+            );
         }
     }
 

--- a/src/v3/RelayRouterV3_NonTstore.sol
+++ b/src/v3/RelayRouterV3_NonTstore.sol
@@ -159,6 +159,9 @@ contract RelayRouterV3_NonTstore is
     /// @param tos The target addresses for the calls
     /// @param datas The data for the calls
     /// @param amounts The amounts to send
+    /// @dev    Emits `FundsMovement` with empty metadata: unlike `cleanupErc20s`
+    ///         this entrypoint takes no metadata argument, so movements cannot be
+    ///         correlated off-chain by request id.
     function cleanupErc20sViaCall(
         address[] calldata tokens,
         address[] calldata tos,
@@ -179,10 +182,10 @@ contract RelayRouterV3_NonTstore is
             address to = tos[i];
             bytes calldata data = datas[i];
 
+            uint256 balanceBefore = IERC20(token).balanceOf(address(this));
+
             // Get the amount to transfer
-            uint256 amount = amounts[i] == 0
-                ? IERC20(token).balanceOf(address(this))
-                : amounts[i];
+            uint256 amount = amounts[i] == 0 ? balanceBefore : amounts[i];
 
             if (amount > 0) {
                 // Approve the target for the call. Use safeApproveWithRetry to
@@ -196,6 +199,20 @@ contract RelayRouterV3_NonTstore is
                 (bool success, ) = to.call(data);
                 if (!success) {
                     revert CallFailed();
+                }
+
+                // Emit the amount the target actually consumed, which can be
+                // less than the amount approved. `to` is the approved spender,
+                // not necessarily the final holder of the tokens.
+                uint256 balanceAfter = IERC20(token).balanceOf(address(this));
+                if (balanceBefore > balanceAfter) {
+                    emit FundsMovement(
+                        address(this),
+                        to,
+                        token,
+                        balanceBefore - balanceAfter,
+                        ""
+                    );
                 }
             }
         }
@@ -237,6 +254,8 @@ contract RelayRouterV3_NonTstore is
     /// @param amount The amount of native tokens to transfer
     /// @param to The target address of the call
     /// @param data The data for the call
+    /// @dev    Emits `FundsMovement` with empty metadata, and does not emit
+    ///         `SolverNativeTransfer` (unlike `cleanupNative`).
     function cleanupNativeViaCall(
         uint256 amount,
         address to,
@@ -249,6 +268,14 @@ contract RelayRouterV3_NonTstore is
             if (!success) {
                 revert CallFailed();
             }
+
+            emit FundsMovement(
+                address(this),
+                to,
+                address(0),
+                amountToTransfer,
+                ""
+            );
         }
     }
 

--- a/src/v3/RelayRouterV3_NonTstore.sol
+++ b/src/v3/RelayRouterV3_NonTstore.sol
@@ -51,6 +51,17 @@ contract RelayRouterV3_NonTstore is
     event SolverNativeTransfer(address to, uint256 amount);
 
     /// @notice Emitted on any explicit movement of funds
+    /// @param from The address the funds left
+    /// @param to The counterparty of the movement. For direct transfers
+    ///        (`multicall`, `cleanupErc20s`, `cleanupNative`,
+    ///        `cleanupNativeViaCall`) this is the address the funds were sent
+    ///        to. For `cleanupErc20sViaCall` it is the call target the router
+    ///        approved, which spends the allowance from within its own code
+    ///        and may deliver the tokens to a different final recipient that
+    ///        the router cannot observe.
+    /// @param currency The token moved, or address(0) for native tokens
+    /// @param amount The amount that actually left `from`
+    /// @param metadata Additional data associated with the movement
     event FundsMovement(
         address from,
         address to,
@@ -161,7 +172,10 @@ contract RelayRouterV3_NonTstore is
     /// @param amounts The amounts to send
     /// @dev    Emits `FundsMovement` with empty metadata: unlike `cleanupErc20s`
     ///         this entrypoint takes no metadata argument, so movements cannot be
-    ///         correlated off-chain by request id.
+    ///         correlated off-chain by request id. The event's `to` is the call
+    ///         target the allowance was granted to, not necessarily the final
+    ///         token recipient — the target may `transferFrom` the router to a
+    ///         third party, which the router cannot observe.
     function cleanupErc20sViaCall(
         address[] calldata tokens,
         address[] calldata tos,

--- a/test/v3/ReentrancyGuardMsgSenderVIG084Test.sol
+++ b/test/v3/ReentrancyGuardMsgSenderVIG084Test.sol
@@ -67,7 +67,9 @@ contract ReentrancyGuardMsgSenderVIG084Test is Test {
     }
 
     function _assertNestedCallDoesNotClearGuard(address router) private {
-        RelayApprovalProxyV3 approvalProxy = new RelayApprovalProxyV3(address(this), router, address(0));
+        // Permit2 is unused on this path but must be non-zero.
+        RelayApprovalProxyV3 approvalProxy =
+            new RelayApprovalProxyV3(address(this), router, makeAddr("permit2"));
 
         address refundTo = makeAddr("refundTo");
         address attemptedRecipient = makeAddr("attemptedRecipient");

--- a/test/v3/RouterProxyHardeningTest.sol
+++ b/test/v3/RouterProxyHardeningTest.sol
@@ -1,0 +1,333 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Test, Vm} from "forge-std/Test.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+import {RelayApprovalProxyV3} from "../../src/v3/RelayApprovalProxyV3.sol";
+import {RelayRouterV3} from "../../src/v3/RelayRouterV3.sol";
+import {RelayRouterV3_NonTstore} from "../../src/v3/RelayRouterV3_NonTstore.sol";
+import {TestERC20} from "../mocks/TestERC20.sol";
+
+/// @notice The permissionless cleanup surface under test, shared by both
+///         router variants.
+interface IRouterCleanup {
+    function cleanupErc20sViaCall(
+        address[] calldata tokens,
+        address[] calldata tos,
+        bytes[] calldata datas,
+        uint256[] calldata amounts
+    ) external;
+
+    function cleanupNativeViaCall(
+        uint256 amount,
+        address to,
+        bytes calldata data
+    ) external;
+}
+
+/// @notice Stands in for a downstream protocol consuming the approval granted
+///         by `cleanupErc20sViaCall`. Pulls a configurable amount so the
+///         partial-consumption path can be exercised.
+contract Erc20Consumer {
+    address public immutable TOKEN;
+    uint256 public pullAmount;
+
+    constructor(address token) {
+        TOKEN = token;
+    }
+
+    function setPullAmount(uint256 amount) external {
+        pullAmount = amount;
+    }
+
+    function pull() external {
+        IERC20(TOKEN).transferFrom(msg.sender, address(this), pullAmount);
+    }
+}
+
+/// @notice Stands in for a downstream protocol consuming native tokens.
+contract NativeConsumer {
+    function deposit() external payable {}
+}
+
+/// @notice An owner whose `receive` hook costs well over the 100k gas stipend
+///         that `_send` used to impose, standing in for a multisig or smart
+///         contract wallet.
+contract GasHungryOwner {
+    uint256[] private filler;
+
+    receive() external payable {
+        for (uint256 i; i < 20; i++) {
+            filler.push(i);
+        }
+    }
+
+    function withdrawFrom(RelayApprovalProxyV3 proxy, address token) external {
+        proxy.withdraw(token);
+    }
+}
+
+/// @title  Router and approval-proxy hardening tests
+/// @notice Covers three vigil findings addressed ahead of the V3 redeployment:
+///
+///           - VIG-RP-026: `cleanupErc20sViaCall` and `cleanupNativeViaCall`
+///             moved funds out of the router without emitting `FundsMovement`,
+///             making the movement invisible to monitoring keyed on that event.
+///           - VIG-RP-113: `_send` capped the owner-only `withdraw` at 100k
+///             gas, stranding the native balance for a contract owner whose
+///             receive hook costs more than the stipend.
+///           - VIG-RP-104: the proxy constructor accepted zero addresses for
+///             immutables and for the owner of its only rescue function.
+contract RouterProxyHardeningTest is Test {
+    event FundsMovement(
+        address from,
+        address to,
+        address currency,
+        uint256 amount,
+        bytes metadata
+    );
+
+    TestERC20 token;
+    address permit2 = address(0xBEEF);
+    address alice = address(0xA11CE);
+
+    function setUp() public {
+        token = new TestERC20();
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // VIG-RP-026: ViaCall cleanups emit FundsMovement
+    // ─────────────────────────────────────────────────────────────────
+
+    function test_erc20ViaCall_emitsFundsMovement_tstore() public {
+        _erc20ViaCallEmits(address(new RelayRouterV3()));
+    }
+
+    function test_erc20ViaCall_emitsFundsMovement_nonTstore() public {
+        _erc20ViaCallEmits(address(new RelayRouterV3_NonTstore()));
+    }
+
+    /// @dev The emitted amount is what the target actually consumed, not what
+    ///      was approved. A target pulling less than the approval must not
+    ///      report the larger figure.
+    function test_erc20ViaCall_emitsConsumedNotApproved_tstore() public {
+        _erc20ViaCallEmitsConsumed(address(new RelayRouterV3()));
+    }
+
+    function test_erc20ViaCall_emitsConsumedNotApproved_nonTstore() public {
+        _erc20ViaCallEmitsConsumed(address(new RelayRouterV3_NonTstore()));
+    }
+
+    /// @dev A target that pulls nothing moves no funds, so it must not emit.
+    ///      Approval events from `safeApproveWithRetry` are expected and are
+    ///      filtered out here.
+    function test_erc20ViaCall_noEventWhenNothingConsumed_tstore() public {
+        _erc20ViaCallEmitsNothing(address(new RelayRouterV3()));
+    }
+
+    function test_erc20ViaCall_noEventWhenNothingConsumed_nonTstore() public {
+        _erc20ViaCallEmitsNothing(address(new RelayRouterV3_NonTstore()));
+    }
+
+    function _erc20ViaCallEmitsNothing(address router) internal {
+        Erc20Consumer consumer = new Erc20Consumer(address(token));
+        token.mint(router, 100 ether);
+        consumer.setPullAmount(0);
+
+        vm.recordLogs();
+        _cleanupErc20(router, address(consumer), 100 ether);
+
+        bytes32 topic = keccak256(
+            "FundsMovement(address,address,address,uint256,bytes)"
+        );
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        for (uint256 i; i < logs.length; i++) {
+            assertTrue(
+                logs[i].topics[0] != topic,
+                "emitted a phantom movement"
+            );
+        }
+
+        assertEq(token.balanceOf(router), 100 ether, "balance moved");
+    }
+
+    function test_nativeViaCall_emitsFundsMovement_tstore() public {
+        _nativeViaCallEmits(address(new RelayRouterV3()));
+    }
+
+    function test_nativeViaCall_emitsFundsMovement_nonTstore() public {
+        _nativeViaCallEmits(address(new RelayRouterV3_NonTstore()));
+    }
+
+    function _erc20ViaCallEmits(address router) internal {
+        Erc20Consumer consumer = new Erc20Consumer(address(token));
+        token.mint(router, 100 ether);
+        consumer.setPullAmount(100 ether);
+
+        vm.expectEmit(true, true, true, true, router);
+        emit FundsMovement(
+            router,
+            address(consumer),
+            address(token),
+            100 ether,
+            ""
+        );
+        // amount 0 means "full balance"
+        _cleanupErc20(router, address(consumer), 0);
+
+        assertEq(token.balanceOf(address(consumer)), 100 ether);
+        assertEq(token.balanceOf(router), 0);
+    }
+
+    function _erc20ViaCallEmitsConsumed(address router) internal {
+        Erc20Consumer consumer = new Erc20Consumer(address(token));
+        token.mint(router, 100 ether);
+        consumer.setPullAmount(40 ether);
+
+        vm.expectEmit(true, true, true, true, router);
+        emit FundsMovement(
+            router,
+            address(consumer),
+            address(token),
+            40 ether,
+            ""
+        );
+        _cleanupErc20(router, address(consumer), 100 ether);
+
+        assertEq(token.balanceOf(router), 60 ether, "residual not left behind");
+    }
+
+    function _nativeViaCallEmits(address router) internal {
+        NativeConsumer consumer = new NativeConsumer();
+        vm.deal(router, 5 ether);
+
+        vm.expectEmit(true, true, true, true, router);
+        emit FundsMovement(
+            router,
+            address(consumer),
+            address(0),
+            5 ether,
+            ""
+        );
+        vm.prank(alice);
+        IRouterCleanup(router).cleanupNativeViaCall(
+            0,
+            address(consumer),
+            abi.encodeCall(NativeConsumer.deposit, ())
+        );
+
+        assertEq(address(consumer).balance, 5 ether);
+        assertEq(router.balance, 0);
+    }
+
+    function _cleanupErc20(
+        address router,
+        address consumer,
+        uint256 amount
+    ) internal {
+        address[] memory tokens = new address[](1);
+        address[] memory tos = new address[](1);
+        bytes[] memory datas = new bytes[](1);
+        uint256[] memory amounts = new uint256[](1);
+        tokens[0] = address(token);
+        tos[0] = consumer;
+        datas[0] = abi.encodeCall(Erc20Consumer.pull, ());
+        amounts[0] = amount;
+
+        vm.prank(alice);
+        IRouterCleanup(router).cleanupErc20sViaCall(
+            tokens,
+            tos,
+            datas,
+            amounts
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // VIG-RP-113: withdraw forwards all gas
+    // ─────────────────────────────────────────────────────────────────
+
+    /// @notice A contract owner whose receive hook costs more than 100k gas can
+    ///         still withdraw the native balance. Under the previous fixed
+    ///         stipend this reverted with NativeTransferFailed.
+    function test_withdrawNative_toGasHungryOwner() public {
+        RelayRouterV3 router = new RelayRouterV3();
+        GasHungryOwner owner = new GasHungryOwner();
+        RelayApprovalProxyV3 proxy = new RelayApprovalProxyV3(
+            address(owner),
+            address(router),
+            permit2
+        );
+
+        vm.deal(address(proxy), 3 ether);
+        owner.withdrawFrom(proxy, address(0));
+
+        assertEq(address(owner).balance, 3 ether, "owner did not receive ETH");
+        assertEq(address(proxy).balance, 0, "proxy still holds ETH");
+    }
+
+    /// @notice The gas-hungry receive hook really does exceed the old stipend,
+    ///         so the test above is not vacuous.
+    function test_gasHungryOwnerExceedsOldStipend() public {
+        GasHungryOwner owner = new GasHungryOwner();
+        uint256 before = gasleft();
+        (bool ok, ) = address(owner).call{value: 0}("");
+        uint256 used = before - gasleft();
+
+        assertTrue(ok);
+        assertGt(used, 100000, "receive hook is cheaper than the old cap");
+    }
+
+    function test_withdrawErc20_stillWorks() public {
+        RelayRouterV3 router = new RelayRouterV3();
+        RelayApprovalProxyV3 proxy = new RelayApprovalProxyV3(
+            alice,
+            address(router),
+            permit2
+        );
+
+        token.mint(address(proxy), 7 ether);
+        vm.prank(alice);
+        proxy.withdraw(address(token));
+
+        assertEq(token.balanceOf(alice), 7 ether);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // VIG-RP-104: constructor rejects zero addresses
+    // ─────────────────────────────────────────────────────────────────
+
+    function test_constructorRejectsZeroOwner() public {
+        address router = address(new RelayRouterV3());
+        vm.expectRevert(
+            RelayApprovalProxyV3.ConstructorArgCannotBeZeroAddress.selector
+        );
+        new RelayApprovalProxyV3(address(0), router, permit2);
+    }
+
+    function test_constructorRejectsZeroRouter() public {
+        vm.expectRevert(
+            RelayApprovalProxyV3.ConstructorArgCannotBeZeroAddress.selector
+        );
+        new RelayApprovalProxyV3(alice, address(0), permit2);
+    }
+
+    function test_constructorRejectsZeroPermit2() public {
+        address router = address(new RelayRouterV3());
+        vm.expectRevert(
+            RelayApprovalProxyV3.ConstructorArgCannotBeZeroAddress.selector
+        );
+        new RelayApprovalProxyV3(alice, router, address(0));
+    }
+
+    function test_constructorAcceptsNonZeroArgs() public {
+        address router = address(new RelayRouterV3());
+        RelayApprovalProxyV3 proxy = new RelayApprovalProxyV3(
+            alice,
+            router,
+            permit2
+        );
+        assertEq(proxy.owner(), alice);
+    }
+}

--- a/test/v3/RouterProxyHardeningTest.sol
+++ b/test/v3/RouterProxyHardeningTest.sol
@@ -32,17 +32,23 @@ interface IRouterCleanup {
 contract Erc20Consumer {
     address public immutable TOKEN;
     uint256 public pullAmount;
+    address public pullRecipient;
 
     constructor(address token) {
         TOKEN = token;
+        pullRecipient = address(this);
     }
 
     function setPullAmount(uint256 amount) external {
         pullAmount = amount;
     }
 
+    function setPullRecipient(address recipient) external {
+        pullRecipient = recipient;
+    }
+
     function pull() external {
-        IERC20(TOKEN).transferFrom(msg.sender, address(this), pullAmount);
+        IERC20(TOKEN).transferFrom(msg.sender, pullRecipient, pullAmount);
     }
 }
 
@@ -152,6 +158,21 @@ contract RouterProxyHardeningTest is Test {
         assertEq(token.balanceOf(router), 100 ether, "balance moved");
     }
 
+    /// @dev The event's `to` is the approved call target by definition: when
+    ///      the target delivers the tokens to a third party, the event still
+    ///      reports the target, since the router cannot observe the final
+    ///      recipient. Pins the semantics documented on `FundsMovement` so
+    ///      the field is not later mistaken for a token recipient.
+    function test_erc20ViaCall_toIsSpenderNotFinalRecipient_tstore() public {
+        _erc20ViaCallReportsSpender(address(new RelayRouterV3()));
+    }
+
+    function test_erc20ViaCall_toIsSpenderNotFinalRecipient_nonTstore()
+        public
+    {
+        _erc20ViaCallReportsSpender(address(new RelayRouterV3_NonTstore()));
+    }
+
     function test_nativeViaCall_emitsFundsMovement_tstore() public {
         _nativeViaCallEmits(address(new RelayRouterV3()));
     }
@@ -196,6 +217,28 @@ contract RouterProxyHardeningTest is Test {
         _cleanupErc20(router, address(consumer), 100 ether);
 
         assertEq(token.balanceOf(router), 60 ether, "residual not left behind");
+    }
+
+    function _erc20ViaCallReportsSpender(address router) internal {
+        Erc20Consumer consumer = new Erc20Consumer(address(token));
+        address thirdParty = address(0x781D);
+        token.mint(router, 100 ether);
+        consumer.setPullAmount(100 ether);
+        consumer.setPullRecipient(thirdParty);
+
+        vm.expectEmit(true, true, true, true, router);
+        emit FundsMovement(
+            router,
+            address(consumer),
+            address(token),
+            100 ether,
+            ""
+        );
+        _cleanupErc20(router, address(consumer), 0);
+
+        assertEq(token.balanceOf(thirdParty), 100 ether, "third party unpaid");
+        assertEq(token.balanceOf(address(consumer)), 0);
+        assertEq(token.balanceOf(router), 0);
     }
 
     function _nativeViaCallEmits(address router) internal {


### PR DESCRIPTION
Three vigil findings on the contracts scheduled for redeployment.

VIG-RP-026: cleanupErc20sViaCall and cleanupNativeViaCall moved funds out
of the router without emitting FundsMovement, so those movements were
invisible to monitoring keyed on that event. The ERC20 variant reports the
amount the target actually consumed rather than the amount approved, which
can differ when a target pulls less than its allowance.

VIG-RP-113: _send capped the transfer at 100k gas. Its only caller is
withdraw, which is onlyOwner, so the cap protected nothing and stranded
the native balance whenever the owner's receive hook cost more than the
stipend. All remaining gas is now forwarded.

VIG-RP-104: the proxy constructor accepted the zero address for ROUTER and
PERMIT2 (immutable) and for the owner of its only rescue function. All
three are unrecoverable after deployment, so they are now validated.

Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>