### PR TITLE
fix: only the outermost frame may clear the NFT recipient slot

### DIFF
--- a/src/RelayApprovalProxy.sol
+++ b/src/RelayApprovalProxy.sol
@@ -80,7 +80,15 @@ contract RelayApprovalProxy is Ownable, EIP712 {
             "RelayerWitness(address relayer,uint256 msgValue,address refundTo,address nftRecipient,bytes metadata,Call3Value[] call3Values)Call3Value(address target,bool allowFailure,uint256 value,bytes callData)"
         );
 
-    receive() external payable {}
+    receive() external payable {
+        emit FundsMovement(
+            msg.sender,
+            address(this),
+            address(0),
+            msg.value,
+            ""
+        );
+    }
 
     constructor(address _owner, address _router, address _permit2) {
         // `ROUTER` and `PERMIT2` are immutable and `_owner` gates the only
@@ -100,13 +108,17 @@ contract RelayApprovalProxy is Ownable, EIP712 {
 
     /// @notice Withdraw function in case funds get stuck in contract
     function withdraw(address token) external onlyOwner {
+        uint256 amount;
         if (token == address(0)) {
-            _send(msg.sender, address(this).balance);
+            amount = address(this).balance;
+            _send(msg.sender, amount);
         } else {
-            IERC20(token).safeTransfer(
-                msg.sender,
-                IERC20(token).balanceOf(address(this))
-            );
+            amount = IERC20(token).balanceOf(address(this));
+            IERC20(token).safeTransfer(msg.sender, amount);
+        }
+
+        if (amount > 0) {
+            emit FundsMovement(address(this), msg.sender, token, amount, "");
         }
     }
 

--- a/src/RelayApprovalProxy.sol
+++ b/src/RelayApprovalProxy.sol
@@ -81,13 +81,15 @@ contract RelayApprovalProxy is Ownable, EIP712 {
         );
 
     receive() external payable {
-        emit FundsMovement(
-            msg.sender,
-            address(this),
-            address(0),
-            msg.value,
-            ""
-        );
+        if (msg.value > 0) {
+            emit FundsMovement(
+                msg.sender,
+                address(this),
+                address(0),
+                msg.value,
+                ""
+            );
+        }
     }
 
     constructor(address _owner, address _router, address _permit2) {

--- a/src/RelayRouter.sol
+++ b/src/RelayRouter.sol
@@ -40,6 +40,10 @@ contract RelayRouter is Multicall3, ReentrancyGuardMsgSender {
     /// @notice Revert if no recipient is set
     error NoRecipientSet();
 
+    /// @notice Revert if a nested multicall requests a different NFT recipient
+    ///         than the one already set by an enclosing frame
+    error RecipientAlreadySet(address current, address requested);
+
     /// @notice Revert if the array lengths do not match
     error ArrayLengthsMismatch();
 
@@ -102,16 +106,31 @@ contract RelayRouter is Multicall3, ReentrancyGuardMsgSender {
             );
         }
 
-        // Set the NFT recipient if provided
+        // Set the NFT recipient if provided. The reentrancy guard admits
+        // nested same-sender calls, so a call inside `calls` may re-enter
+        // `multicall`. Only the frame that acquired the recipient may clear
+        // it: a nested frame clearing it would leave every later NFT callback
+        // in the enclosing frame reading a zero recipient, reverting with
+        // `NoRecipientSet` — or, under `allowFailure`, swallowing that revert
+        // so the mint never happens and the multicall still reports success.
+        bool recipientSetHere;
         if (nftRecipient != address(0)) {
-            _setRecipient(nftRecipient);
+            address currentRecipient = _getRecipient();
+            if (currentRecipient == address(0)) {
+                _setRecipient(nftRecipient);
+                recipientSetHere = true;
+            } else if (currentRecipient != nftRecipient) {
+                revert RecipientAlreadySet(currentRecipient, nftRecipient);
+            }
         }
 
         // Perform the multicall
         returnData = _aggregate3Value(calls);
 
         // Clear the recipient in storage
-        _clearRecipient();
+        if (recipientSetHere) {
+            _clearRecipient();
+        }
 
         // Refund any leftover native tokens to the sender
         cleanupNative(0, refundTo, metadata);

--- a/src/RelayRouter.sol
+++ b/src/RelayRouter.sol
@@ -312,7 +312,14 @@ contract RelayRouter is Multicall3, ReentrancyGuardMsgSender {
     }
 
     /// @notice Internal function to set the recipient address for ERC721 or ERC1155 mint
-    /// @dev If the chain does not support tstore, recipient will be saved in storage
+    /// @dev This slot is always persistent storage, in both router variants.
+    ///      Unlike the reentrancy guard — which is transient in `RelayRouter`
+    ///      and persistent only in `RelayRouter_NonTstore` — the recipient is
+    ///      written with `sstore` regardless of tstore support. Setting a
+    ///      non-zero recipient therefore costs a cold `SSTORE` plus a clear on
+    ///      the way out, and only the ERC721/ERC1155 receive hooks ever read
+    ///      it: callers whose multicall receives no such tokens should pass
+    ///      `address(0)` rather than paying for a slot nothing will read.
     /// @param recipient The address of the recipient
     function _setRecipient(address recipient) internal {
         // For safety, revert if the recipient is this contract

--- a/src/RelayRouter_NonTstore.sol
+++ b/src/RelayRouter_NonTstore.sol
@@ -317,7 +317,14 @@ contract RelayRouter_NonTstore is
     }
 
     /// @notice Internal function to set the recipient address for ERC721 or ERC1155 mint
-    /// @dev If the chain does not support tstore, recipient will be saved in storage
+    /// @dev This slot is always persistent storage, in both router variants.
+    ///      Unlike the reentrancy guard — which is transient in `RelayRouter`
+    ///      and persistent only in `RelayRouter_NonTstore` — the recipient is
+    ///      written with `sstore` regardless of tstore support. Setting a
+    ///      non-zero recipient therefore costs a cold `SSTORE` plus a clear on
+    ///      the way out, and only the ERC721/ERC1155 receive hooks ever read
+    ///      it: callers whose multicall receives no such tokens should pass
+    ///      `address(0)` rather than paying for a slot nothing will read.
     /// @param recipient The address of the recipient
     function _setRecipient(address recipient) internal {
         // For safety, revert if the recipient is this contract

--- a/src/RelayRouter_NonTstore.sol
+++ b/src/RelayRouter_NonTstore.sol
@@ -45,6 +45,10 @@ contract RelayRouter_NonTstore is
     /// @notice Revert if no recipient is set
     error NoRecipientSet();
 
+    /// @notice Revert if a nested multicall requests a different NFT recipient
+    ///         than the one already set by an enclosing frame
+    error RecipientAlreadySet(address current, address requested);
+
     /// @notice Revert if the array lengths do not match
     error ArrayLengthsMismatch();
 
@@ -107,16 +111,31 @@ contract RelayRouter_NonTstore is
             );
         }
 
-        // Set the NFT recipient if provided
+        // Set the NFT recipient if provided. The reentrancy guard admits
+        // nested same-sender calls, so a call inside `calls` may re-enter
+        // `multicall`. Only the frame that acquired the recipient may clear
+        // it: a nested frame clearing it would leave every later NFT callback
+        // in the enclosing frame reading a zero recipient, reverting with
+        // `NoRecipientSet` — or, under `allowFailure`, swallowing that revert
+        // so the mint never happens and the multicall still reports success.
+        bool recipientSetHere;
         if (nftRecipient != address(0)) {
-            _setRecipient(nftRecipient);
+            address currentRecipient = _getRecipient();
+            if (currentRecipient == address(0)) {
+                _setRecipient(nftRecipient);
+                recipientSetHere = true;
+            } else if (currentRecipient != nftRecipient) {
+                revert RecipientAlreadySet(currentRecipient, nftRecipient);
+            }
         }
 
         // Perform the multicall
         returnData = _aggregate3Value(calls);
 
         // Clear the recipient in storage
-        _clearRecipient();
+        if (recipientSetHere) {
+            _clearRecipient();
+        }
 
         // Refund any leftover native tokens to the sender
         cleanupNative(0, refundTo, metadata);

--- a/src/common/Multicall3.sol
+++ b/src/common/Multicall3.sol
@@ -26,6 +26,9 @@ struct Result {
 /// @author Andreas Bigger <andreas@nascent.xyz>
 /// @author Matt Solomon <matt@mattsolomon.dev>
 contract Multicall3 {
+    /// @notice Revert if a call targets the zero address
+    error InvalidTarget(address target);
+
     event SolverCallExecuted(address to, bytes data, uint256 amount);
 
     /// @notice Aggregate calls
@@ -39,6 +42,15 @@ contract Multicall3 {
         for (uint256 i = 0; i < length;) {
             Result memory result = returnData[i];
             calli = calls[i];
+
+            // A `CALL` to the zero address returns success and permanently
+            // burns any value forwarded with it, and `SolverCallExecuted`
+            // would then report the burn as a successful call. Reject it
+            // regardless of `allowFailure`: a zero target is a malformed
+            // call, not a failure worth tolerating.
+            if (calli.target == address(0)) {
+                revert InvalidTarget(address(0));
+            }
 
             uint256 val = calli.value;
             (result.success, result.returnData) = calli.target.call{value: val}(calli.callData);

--- a/test/MulticallZeroTargetTest.sol
+++ b/test/MulticallZeroTargetTest.sol
@@ -1,0 +1,110 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Test} from "forge-std/Test.sol";
+
+import {Call3Value} from "../src/common/Multicall3.sol";
+import {RelayRouter} from "../src/RelayRouter.sol";
+import {RelayRouter_NonTstore} from "../src/RelayRouter_NonTstore.sol";
+
+interface IZeroTargetRouter {
+    function multicall(
+        Call3Value[] calldata calls,
+        address refundTo,
+        address nftRecipient,
+        bytes calldata metadata
+    ) external payable;
+}
+
+/// @title  Zero-target call rejection (VIG-RP-097)
+/// @notice A `CALL` to `address(0)` returns success on the EVM and permanently
+///         burns any value forwarded with it, while `SolverCallExecuted` would
+///         report it as a successful call. `_aggregate3Value` performed no
+///         target validation, so a malformed `calls` entry silently destroyed
+///         native tokens and left a log line claiming it had worked.
+contract MulticallZeroTargetTest is Test {
+    error InvalidTarget(address target);
+
+    address alice = address(0xA11CE);
+
+    function test_zeroTargetWithValueReverts_tstore() public {
+        _revertsWithValue(address(new RelayRouter()));
+    }
+
+    function test_zeroTargetWithValueReverts_nonTstore() public {
+        _revertsWithValue(address(new RelayRouter_NonTstore()));
+    }
+
+    /// @notice Rejected even with no value attached: the call would still
+    ///         report success and emit an event for something that did nothing.
+    function test_zeroTargetWithoutValueReverts_tstore() public {
+        _revertsWithoutValue(address(new RelayRouter()));
+    }
+
+    function test_zeroTargetWithoutValueReverts_nonTstore() public {
+        _revertsWithoutValue(address(new RelayRouter_NonTstore()));
+    }
+
+    /// @notice `allowFailure` must not turn the rejection into a swallowed
+    ///         no-op, which would put the burn back.
+    function test_zeroTargetRejectedDespiteAllowFailure_tstore() public {
+        _revertsAllowFailure(address(new RelayRouter()));
+    }
+
+    function test_zeroTargetRejectedDespiteAllowFailure_nonTstore() public {
+        _revertsAllowFailure(address(new RelayRouter_NonTstore()));
+    }
+
+    function _call(
+        bool allowFailure,
+        uint256 value
+    ) internal pure returns (Call3Value[] memory calls) {
+        calls = new Call3Value[](1);
+        calls[0] = Call3Value({
+            target: address(0),
+            allowFailure: allowFailure,
+            value: value,
+            callData: ""
+        });
+    }
+
+    function _revertsWithValue(address router) internal {
+        vm.deal(alice, 1 ether);
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(InvalidTarget.selector, address(0))
+        );
+        IZeroTargetRouter(router).multicall{value: 1 ether}(
+            _call(false, 1 ether),
+            alice,
+            address(0),
+            ""
+        );
+
+        assertEq(alice.balance, 1 ether, "value should not have moved");
+    }
+
+    function _revertsWithoutValue(address router) internal {
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(InvalidTarget.selector, address(0))
+        );
+        IZeroTargetRouter(router).multicall(_call(false, 0), alice, address(0), "");
+    }
+
+    function _revertsAllowFailure(address router) internal {
+        vm.deal(alice, 1 ether);
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(InvalidTarget.selector, address(0))
+        );
+        IZeroTargetRouter(router).multicall{value: 1 ether}(
+            _call(true, 1 ether),
+            alice,
+            address(0),
+            ""
+        );
+
+        assertEq(alice.balance, 1 ether, "value should not have moved");
+    }
+}

--- a/test/RelayRouterRecipientSlotTest.sol
+++ b/test/RelayRouterRecipientSlotTest.sol
@@ -1,0 +1,224 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.25;
+
+import {Test} from "forge-std/Test.sol";
+
+import {Call3Value} from "../src/common/Multicall3.sol";
+import {RelayRouter} from "../src/RelayRouter.sol";
+import {RelayRouter_NonTstore} from "../src/RelayRouter_NonTstore.sol";
+import {TestERC721} from "./mocks/TestERC721.sol";
+
+/// @notice The subset of the router surface these tests drive, shared by both
+///         storage variants.
+interface IRecipientRouter {
+    function multicall(
+        Call3Value[] calldata calls,
+        address refundTo,
+        address nftRecipient,
+        bytes calldata metadata
+    ) external payable;
+}
+
+/// @title  NFT recipient slot regression tests (VIG-RP-003 / 004 / 025)
+/// @notice The reentrancy guard admits nested same-sender calls, so a call
+///         inside `calls` can re-enter `multicall`. Before the fix, the nested
+///         frame ran `_clearRecipient()` unconditionally and zeroed the
+///         enclosing frame's NFT recipient while it was still executing. Any
+///         later NFT callback then read a zero recipient and reverted with
+///         `NoRecipientSet`. With `allowFailure: true` that revert was
+///         swallowed: the mint or transfer never happened, the multicall
+///         reported success, and the user got nothing.
+///
+///         Note this is narrower than VIG-RP-003 claims. The finding says the
+///         NFT is "minted to the router" and stranded; it is not. The receiver
+///         hook reverts inside `_safeMint`, which unwinds the mint atomically,
+///         so no token is created and nothing is left on the router. The
+///         damage is a silently swallowed mint, not a stranded asset.
+///
+///         #62 fixed the reentrancy guard slot but not the recipient slot, and
+///         made the nested path cleanly reachable in the process.
+contract RelayRouterRecipientSlotTest is Test {
+    error RecipientAlreadySet(address current, address requested);
+
+    TestERC721 nft;
+    address alice = address(0xA11CE);
+    address bob = address(0xB0B);
+
+    function setUp() public {
+        nft = new TestERC721();
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Baseline
+    // ─────────────────────────────────────────────────────────────────
+
+    function test_baseline_recipientReceivesNft_tstore() public {
+        _baseline(address(new RelayRouter()));
+    }
+
+    function test_baseline_recipientReceivesNft_nonTstore() public {
+        _baseline(address(new RelayRouter_NonTstore()));
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // The regression: a nested frame must not clear the recipient
+    // ─────────────────────────────────────────────────────────────────
+
+    /// @notice A nested multicall that sets no recipient of its own must leave
+    ///         the enclosing frame's recipient intact.
+    function test_nestedCallKeepsRecipient_tstore() public {
+        _nestedKeepsRecipient(address(new RelayRouter()));
+    }
+
+    function test_nestedCallKeepsRecipient_nonTstore() public {
+        _nestedKeepsRecipient(address(new RelayRouter_NonTstore()));
+    }
+
+    /// @notice Same nesting with `allowFailure: true` on the mint. Before the
+    ///         fix the callback reverted, the revert was swallowed, and the
+    ///         mint never happened while the multicall reported success.
+    function test_nestedCallKeepsRecipient_allowFailure_tstore() public {
+        _nestedKeepsRecipientAllowFailure(address(new RelayRouter()));
+    }
+
+    function test_nestedCallKeepsRecipient_allowFailure_nonTstore() public {
+        _nestedKeepsRecipientAllowFailure(
+            address(new RelayRouter_NonTstore())
+        );
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Conflicting and matching nested recipients
+    // ─────────────────────────────────────────────────────────────────
+
+    /// @notice A nested frame asking for a different recipient is a genuine
+    ///         conflict and must revert rather than silently reroute.
+    function test_nestedConflictingRecipientReverts_tstore() public {
+        _nestedConflictReverts(address(new RelayRouter()));
+    }
+
+    function test_nestedConflictingRecipientReverts_nonTstore() public {
+        _nestedConflictReverts(address(new RelayRouter_NonTstore()));
+    }
+
+    /// @notice A nested frame asking for the same recipient is a no-op.
+    function test_nestedMatchingRecipientAllowed_tstore() public {
+        _nestedMatchingAllowed(address(new RelayRouter()));
+    }
+
+    function test_nestedMatchingRecipientAllowed_nonTstore() public {
+        _nestedMatchingAllowed(address(new RelayRouter_NonTstore()));
+    }
+
+    /// @notice The recipient does not leak past the outer frame.
+    function test_recipientClearedAfterOuterCall_tstore() public {
+        _recipientCleared(address(new RelayRouter()));
+    }
+
+    function test_recipientClearedAfterOuterCall_nonTstore() public {
+        _recipientCleared(address(new RelayRouter_NonTstore()));
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // Helpers
+    // ─────────────────────────────────────────────────────────────────
+
+    function _mintCall(
+        uint256 tokenId,
+        bool allowFailure
+    ) internal view returns (Call3Value memory) {
+        return
+            Call3Value({
+                target: address(nft),
+                allowFailure: allowFailure,
+                value: 0,
+                callData: abi.encodeWithSignature("safeMint(uint256)", tokenId)
+            });
+    }
+
+    function _nestedCall(
+        address router,
+        address nestedRecipient
+    ) internal view returns (Call3Value memory) {
+        Call3Value[] memory none = new Call3Value[](0);
+        return
+            Call3Value({
+                target: router,
+                allowFailure: false,
+                value: 0,
+                callData: abi.encodeCall(
+                    IRecipientRouter.multicall,
+                    (none, alice, nestedRecipient, "")
+                )
+            });
+    }
+
+    function _baseline(address router) internal {
+        Call3Value[] memory calls = new Call3Value[](1);
+        calls[0] = _mintCall(1, false);
+
+        vm.prank(alice);
+        IRecipientRouter(router).multicall(calls, alice, alice, "");
+
+        assertEq(nft.ownerOf(1), alice);
+    }
+
+    function _nestedKeepsRecipient(address router) internal {
+        Call3Value[] memory calls = new Call3Value[](2);
+        calls[0] = _nestedCall(router, address(0));
+        calls[1] = _mintCall(1, false);
+
+        vm.prank(alice);
+        IRecipientRouter(router).multicall(calls, alice, alice, "");
+
+        assertEq(nft.ownerOf(1), alice, "recipient lost after nested call");
+        assertEq(nft.balanceOf(router), 0, "NFT left on the router");
+    }
+
+    function _nestedKeepsRecipientAllowFailure(address router) internal {
+        Call3Value[] memory calls = new Call3Value[](2);
+        calls[0] = _nestedCall(router, address(0));
+        calls[1] = _mintCall(1, true);
+
+        vm.prank(alice);
+        IRecipientRouter(router).multicall(calls, alice, alice, "");
+
+        assertEq(nft.ownerOf(1), alice, "mint silently swallowed");
+        assertEq(nft.balanceOf(router), 0, "NFT left on the router");
+    }
+
+    function _nestedConflictReverts(address router) internal {
+        Call3Value[] memory calls = new Call3Value[](1);
+        calls[0] = _nestedCall(router, bob);
+
+        vm.prank(alice);
+        vm.expectRevert(
+            abi.encodeWithSelector(RecipientAlreadySet.selector, alice, bob)
+        );
+        IRecipientRouter(router).multicall(calls, alice, alice, "");
+    }
+
+    function _nestedMatchingAllowed(address router) internal {
+        Call3Value[] memory calls = new Call3Value[](2);
+        calls[0] = _nestedCall(router, alice);
+        calls[1] = _mintCall(1, false);
+
+        vm.prank(alice);
+        IRecipientRouter(router).multicall(calls, alice, alice, "");
+
+        assertEq(nft.ownerOf(1), alice);
+    }
+
+    function _recipientCleared(address router) internal {
+        Call3Value[] memory calls = new Call3Value[](1);
+        calls[0] = _mintCall(1, false);
+
+        vm.prank(alice);
+        IRecipientRouter(router).multicall(calls, alice, alice, "");
+
+        // With no recipient set, the callback has nowhere to forward to.
+        vm.prank(alice);
+        vm.expectRevert();
+        nft.safeMint(router, 2);
+    }
+}

--- a/test/RouterProxyHardeningTest.sol
+++ b/test/RouterProxyHardeningTest.sol
@@ -85,6 +85,10 @@ contract GasHungryOwner {
 ///             receive hook costs more than the stipend.
 ///           - VIG-RP-104: the proxy constructor accepted zero addresses for
 ///             immutables and for the owner of its only rescue function.
+///           - VIG-RP-092: withdraw() was the only fund-movement path in the
+///             proxy that emitted no FundsMovement.
+///           - VIG-RP-105: receive() accepted native tokens silently, so with
+///             092 the whole ETH lifecycle through the proxy was invisible.
 contract RouterProxyHardeningTest is Test {
     event FundsMovement(
         address from,
@@ -97,6 +101,7 @@ contract RouterProxyHardeningTest is Test {
     TestERC20 token;
     address permit2 = address(0xBEEF);
     address alice = address(0xA11CE);
+    address bob = address(0xB0B);
 
     function setUp() public {
         token = new TestERC20();
@@ -335,6 +340,70 @@ contract RouterProxyHardeningTest is Test {
         proxy.withdraw(address(token));
 
         assertEq(token.balanceOf(alice), 7 ether);
+    }
+
+    // ─────────────────────────────────────────────────────────────────
+    // VIG-RP-092 / 105: the proxy's own ETH lifecycle is observable
+    // ─────────────────────────────────────────────────────────────────
+
+    function test_receive_emitsFundsMovement() public {
+        RelayApprovalProxy proxy = _proxy(alice);
+
+        vm.deal(bob, 1 ether);
+        vm.expectEmit(true, true, true, true, address(proxy));
+        emit FundsMovement(bob, address(proxy), address(0), 1 ether, "");
+
+        vm.prank(bob);
+        (bool ok, ) = address(proxy).call{value: 1 ether}("");
+        assertTrue(ok);
+    }
+
+    function test_withdrawNative_emitsFundsMovement() public {
+        RelayApprovalProxy proxy = _proxy(alice);
+        vm.deal(address(proxy), 2 ether);
+
+        vm.expectEmit(true, true, true, true, address(proxy));
+        emit FundsMovement(address(proxy), alice, address(0), 2 ether, "");
+
+        vm.prank(alice);
+        proxy.withdraw(address(0));
+    }
+
+    function test_withdrawErc20_emitsFundsMovement() public {
+        RelayApprovalProxy proxy = _proxy(alice);
+        token.mint(address(proxy), 5 ether);
+
+        vm.expectEmit(true, true, true, true, address(proxy));
+        emit FundsMovement(address(proxy), alice, address(token), 5 ether, "");
+
+        vm.prank(alice);
+        proxy.withdraw(address(token));
+    }
+
+    /// @notice Nothing to move, nothing to report.
+    function test_withdraw_noEventWhenEmpty() public {
+        RelayApprovalProxy proxy = _proxy(alice);
+
+        vm.recordLogs();
+        vm.prank(alice);
+        proxy.withdraw(address(token));
+
+        bytes32 topic = keccak256(
+            "FundsMovement(address,address,address,uint256,bytes)"
+        );
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        for (uint256 i; i < logs.length; i++) {
+            assertTrue(logs[i].topics[0] != topic, "phantom movement");
+        }
+    }
+
+    function _proxy(address owner) internal returns (RelayApprovalProxy) {
+        return
+            new RelayApprovalProxy(
+                owner,
+                address(new RelayRouter()),
+                permit2
+            );
     }
 
     // ─────────────────────────────────────────────────────────────────

--- a/test/RouterProxyHardeningTest.sol
+++ b/test/RouterProxyHardeningTest.sol
@@ -358,6 +358,25 @@ contract RouterProxyHardeningTest is Test {
         assertTrue(ok);
     }
 
+    /// @notice A zero-value call to receive() moves nothing, so it must not
+    ///         emit — matching the VIG-RP-106 guards on the permit paths.
+    function test_receive_noEventOnZeroValue() public {
+        RelayApprovalProxy proxy = _proxy(alice);
+
+        vm.recordLogs();
+        vm.prank(bob);
+        (bool ok, ) = address(proxy).call{value: 0}("");
+        assertTrue(ok);
+
+        bytes32 topic = keccak256(
+            "FundsMovement(address,address,address,uint256,bytes)"
+        );
+        Vm.Log[] memory logs = vm.getRecordedLogs();
+        for (uint256 i; i < logs.length; i++) {
+            assertTrue(logs[i].topics[0] != topic, "phantom movement");
+        }
+    }
+
     function test_withdrawNative_emitsFundsMovement() public {
         RelayApprovalProxy proxy = _proxy(alice);
         vm.deal(address(proxy), 2 ether);


### PR DESCRIPTION
## Summary

**Stacked on #67** — base is `cleanup/unversioned-contracts`. Retargets to `main` once #67 lands.

This basically preserves the NFT recipient across nested multicalls so an inner call cannot clear or replace the outer call’s recipient. This prevents NFT mints from silently failing while the overall multicall reports success. It also adds missing fund-movement events for ETH deposits and owner withdrawals from the approval proxy.

---

### VIG-RP-003 / 004 / 025 — the recipient slot

#62 fixed the reentrancy guard slot but left `RECIPIENT_STORAGE_SLOT` with the same defect — and made the nested path cleanly reachable in the process, since nested same-sender calls now proceed instead of half-breaking on the guard.

`multicall` called `_clearRecipient()` unconditionally, so a call inside `calls` that re-entered `multicall` zeroed the enclosing frame's NFT recipient while the outer frame was still executing. Later NFT callbacks in the outer frame then read a zero recipient and reverted `NoRecipientSet`. Under `allowFailure: true` that revert was swallowed: the mint never happened and the multicall still reported success.

Only the frame that acquired the recipient may clear it. A nested frame asking for a *different* recipient is a genuine conflict and now reverts `RecipientAlreadySet(current, requested)` rather than silently rerouting the NFT; asking for the same recipient, or for none, is a no-op. That keeps every single-level flow byte-for-byte identical.

**One correction to the finding.** VIG-RP-003 says the NFT is "minted to the router with no recipient ever set" and stranded. It is not. OpenZeppelin's `_safeMint` unwinds atomically when the receiver hook reverts, so no token is created and nothing is left on the router — `test_nestedCallKeepsRecipient_allowFailure_*` fails with `ERC721NonexistentToken(1)` before the fix, not with a router-held balance. The damage is a silently swallowed mint, which is arguably worse for a user (they pay, the call succeeds, no NFT arrives) but does not need a sweep function to recover. Worth correcting when the finding's status gets updated.

### VIG-RP-092 / 105 — the proxy's ETH lifecycle

`withdraw()` was the only fund-movement path in the proxy emitting no `FundsMovement`, and `receive()` accepted native tokens completely silently. Together the proxy's whole native lifecycle was invisible to monitoring. Both now emit, with `withdraw` reporting the actual amount moved and staying quiet when there was nothing to move. Same class as the VIG-RP-026 fix in #64, and the natural home for them is here rather than a third PR.

### VIG-RP-097 — calls targeting the zero address

A `CALL` to `address(0)` returns `success = true` on the EVM and credits the forwarded value to an account nobody controls, and `SolverCallExecuted` then reported the loss as a successful call. Nothing in `multicall`, `transferAndMulticall`, or the permit entry points validated targets before forwarding the `calls` array.

Now rejected with `InvalidTarget(address(0))` **regardless of `allowFailure`** — a zero target is a malformed call, not a failure worth tolerating, and swallowing it would put the loss straight back.

This one has a real if small cost, so it should be a deliberate choice rather than waved through: **roughly 146 gas per call in every multicall**. `testRouter__Multicall__TwoSwaps` goes 208,393 → 208,685 over two calls, `SwapAndCallWithCleanup` 1,047,049 → 1,047,487 over three. The realistic trigger is a solver bug rather than an attacker, since `calls` is signed — happy to drop this commit if that trade isn't worth it to you.

Six tests in `test/MulticallZeroTargetTest.sol`, both variants, all six failing without the change (the multicall simply succeeds).

## Not doing: VIG-RP-077

The finding asks for `nonReentrant` on `onERC721Received` / `onERC1155Received` / `onERC1155BatchReceived`. **Adding it would break every NFT flow in the router.** During a multicall the guard holds the outer caller's address; the token contract firing the callback has a different `msg.sender`, so the modifier would revert on the legitimate path. The hooks are reachable only while a recipient is set — i.e. inside an active multicall whose guard is held by the outer sender — so a rogue callback still cannot re-enter any guarded function. #62 is what actually hardened this. Recommend marking it `INVALID`.

## Tests

New `test/RelayRouterRecipientSlotTest.sol`, 12 cases, both storage variants, no fork dependency:

- baseline: recipient receives the NFT
- nested multicall with no recipient of its own leaves the outer recipient intact
- same nesting with `allowFailure: true` — the mint actually happens instead of being swallowed
- nested frame requesting a different recipient reverts `RecipientAlreadySet`
- nested frame requesting the same recipient is allowed
- the recipient does not leak past the outer frame

**8 of the 12 fail without the src change** (`NoRecipientSet`, `ERC721NonexistentToken`, and two missing reverts), so they are not vacuous — I checked by stashing only the router diff.

Five more in `RouterProxyHardeningTest` for 092/105, including a no-phantom-event case for an empty `withdraw`.

```
forge build   # clean
forge test    # 66 passed, 6 failed
```

Baseline on `cleanup/unversioned-contracts` is 44 passed / 6 failed. Same 6 failures, +22 new tests. The failures are the pre-existing mainnet-fork ones documented on #64/#65.

## After this

The vigil `findings` branch needs a status sweep — 001, 003, 004, 017, 022, 025, 026, 034, 055, 075, 077, 084, 092, 101, 104, 105, 106, 107, 113, 114, 118 have all been resolved, invalidated, or mis-triaged across #62–#68. Sending that as a separate PR there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

