### PR TITLE
chore: record arc v3.1 deployment (DEC-1841)

### DIFF
--- a/deployments/v3/addresses.json
+++ b/deployments/v3/addresses.json
@@ -935,8 +935,8 @@
     "compilerVersion": "0.8.28",
     "evmVersion": "cancun",
     "explorerUrl": "",
-    "relayRouter": "0xb92fe925dc43a0ecde6c8b1a2709c170ec4fff4f",
-    "relayApprovalProxy": "0xccc88a9d1b4ed6b0eaba998850414b24f1c315be",
+    "relayRouter": "0xe6b730e58088884704cdf11cbe95c224d4d34154",
+    "relayApprovalProxy": "0x5a0fa369d634f49c76b08dc6c299800c1a2af977",
     "create2Factory": "0x4e59b44847b379578588920ca78fbf26c0b4956c",
     "permit2": "0x000000000022d473030f116ddee9f6b43ac78ba3"
   },


### PR DESCRIPTION
Records the arc (chain 5042) v3.1 deployment in `addresses.json`
- RelayRouter `0xe6B730e58088884704CDF11cbE95c224d4D34154`, RelayApprovalProxy `0x5A0fA369d634f49c76B08dC6C299800C1a2aF977` — the canonical v3.1 cancun addresses; `owner()` confirmed as `0x463cB782c8dd0a1887b77336DfF74D60F006F56E` on-chain.
- Deployment funding note: Arc gas is native USDC; CCTP transfers to Arc were stuck (Circle-side attestation outage), so the deployer was funded by direct transfer.
- Contracts are NOT source-verified yet: Arc's explorer exposes no verification API and the chain is not on Etherscan v2 or sourcify. To be done when their explorer opens up.

With this, v3.1 is live on **58 of 59 target chains** (syndicate dropped — chain dead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)